### PR TITLE
Option for smaller announcer text font, defaults to off (vanilla size)

### DIFF
--- a/Functions/client/fn_WL2_initClient.sqf
+++ b/Functions/client/fn_WL2_initClient.sqf
@@ -74,6 +74,7 @@ MRTM_playKillSound = true;
 MRTM_muteVoiceInformer = false;
 MRTM_EnableRWR = true;
 MRTM_disableHint = true;
+MRTM_smallAnnouncerText = false;
 has_recieved_reward = false;
 reward_active = false;
 

--- a/Functions/client/fn_WL2_smoothText.sqf
+++ b/Functions/client/fn_WL2_smoothText.sqf
@@ -61,10 +61,13 @@ if (count BIS_onScreenMessagesVisible > 1) then {
 	} forEach (BIS_onScreenMessagesVisible - [_messageID]);
 };
 
-_box ctrlSetPosition [_xDef, _yDef + (_hDef / 4), _wDef, _hDef / 25];
+_announcerPositionRatio = if (MRTM_smallAnnouncerText) then { 8 } else { 4 };
+_announcerSizeRatio = if (MRTM_smallAnnouncerText) then { 50 } else { 25 };
+
+_box ctrlSetPosition [_xDef, _yDef + (_hDef / _announcerPositionRatio), _wDef, _hDef / _announcerSizeRatio];
 _box ctrlSetBackgroundColor [0, 0, 0, 0];
 _box ctrlSetTextColor _color;
-_box ctrlSetFontHeight (_hDef / 25);
+_box ctrlSetFontHeight (_hDef / _announcerSizeRatio);
 _box ctrlCommit 0;
 
 _textArr = toArray _text;

--- a/scripts/MRTM_settings/fn_openMenu.sqf
+++ b/scripts/MRTM_settings/fn_openMenu.sqf
@@ -66,3 +66,9 @@ if (MRTM_disableHint) then {
 } else {
 	((findDisplay 8000) displayCtrl 2805) cbSetChecked false;
 };
+
+if (MRTM_smallAnnouncerText) then {
+	((findDisplay 8000) displayCtrl 2806) cbSetChecked true;
+} else {
+	((findDisplay 8000) displayCtrl 2806) cbSetChecked false;
+};

--- a/ui/controls.hpp
+++ b/ui/controls.hpp
@@ -785,8 +785,7 @@ class MRTM_settingsMenu
 		class MRTMOtherButton6: RscCheckboxMRTM
 		{
 			idc = 2806;
-			action = "";
-			onLoad =  "(_this # 0) ctrlEnable false;";
+			action = "if (MRTM_smallAnnouncerText) then {MRTM_smallAnnouncerText = false} else {MRTM_smallAnnouncerText = true}";
 			x = 0.463906 * safezoneW + safezoneX;
 			y = 0.665 * safezoneH + safezoneY;
 			w = 0.0154688 * safezoneW;
@@ -900,7 +899,7 @@ class MRTM_settingsMenu
 		class MRTMOtherText6: RscStructuredTextMRTM
 		{
 			idc = 1122;
-			text = "";
+			text = "Small announcer font";
 			x = 0.481437 * safezoneW + safezoneX;
 			y = 0.665 * safezoneH + safezoneY;
 			w = 0.221719 * safezoneW;


### PR DESCRIPTION
![Option menu](https://github.com/Gamer-Dad/warlordsredux.altis/assets/5867121/14c8c665-eca5-4418-8e2c-8f2ce1f398e4)

![20230711103113_1](https://github.com/Gamer-Dad/warlordsredux.altis/assets/5867121/aa4a1028-c283-4388-96ab-37e9519e7289)
![20230711103022_1](https://github.com/Gamer-Dad/warlordsredux.altis/assets/5867121/da0b9b65-9efa-42db-87de-4326d788a579)
![20230711103036_1](https://github.com/Gamer-Dad/warlordsredux.altis/assets/5867121/42332d80-db08-40d1-900a-0bb98984ba69)
