### PR TITLE
Better APS performance

### DIFF
--- a/scripts/DAPS/Scripts/APS/fn_APSheavy.fsm
+++ b/scripts/DAPS/Scripts/APS/fn_APSheavy.fsm
@@ -112,7 +112,7 @@ class FSM
                                         priority = 0.000000;
                                         to="Trigger";
                                         precondition = /*%FSM<CONDPRECONDITION""">*/""/*%FSM</CONDPRECONDITION""">*/;
-                                        condition=/*%FSM<CONDITION""">*/"((count (nearestObjects [_v, [""R_TBG32V_F"", ""M_NLAW_AT_F"", ""M_AT"", ""M_PG_AT"", ""M_Scalpel_AT"", ""M_Scalpel_AT_hidden"", ""M_SPG9_HE"", ""M_SPG9_HEAT"", ""M_Titan_AP"", ""M_Titan_AT"", ""M_Titan_AT_long"", ""M_Titan_AT_static"", ""M_Vorona_HE"", ""M_Vorona_HEAT"", ""Missile_AGM_01_F"", ""Missile_AGM_02_F"", ""R_MRAAWS_HE_F"", ""R_MRAAWS_HEAT_F"", ""R_MRAAWS_HEAT55_F"", ""R_PG32V_F"", ""R_PG7_F"", ""Rocket_03_AP_F"", ""Rocket_03_HE_F"", ""Rocket_04_AP_F"", ""Rocket_04_HE_F""], 125])) > 0) && {_v call DAPS_fnc_active};"/*%FSM</CONDITION""">*/;
+                                        condition=/*%FSM<CONDITION""">*/"((_v nearObjects [""MissileCore"", 125]) + (_v nearObjects [""RocketCore"", 125])) findIf { (typeOf _x) in [""R_TBG32V_F"", ""M_NLAW_AT_F"", ""M_AT"", ""M_PG_AT"", ""M_Scalpel_AT"", ""M_Scalpel_AT_hidden"", ""M_SPG9_HE"", ""M_SPG9_HEAT"", ""M_Titan_AP"", ""M_Titan_AT"", ""M_Titan_AT_long"", ""M_Titan_AT_static"", ""M_Vorona_HE"", ""M_Vorona_HEAT"", ""Missile_AGM_01_F"", ""Missile_AGM_02_F"", ""R_MRAAWS_HE_F"", ""R_MRAAWS_HEAT_F"", ""R_MRAAWS_HEAT55_F"", ""R_PG32V_F"", ""R_PG7_F"", ""Rocket_03_AP_F"", ""Rocket_03_HE_F"", ""Rocket_04_AP_F"", ""Rocket_04_HE_F""] } > -1 && {_v call DAPS_fnc_active};"/*%FSM</CONDITION""">*/;
                                         action=/*%FSM<ACTION""">*/""/*%FSM</ACTION""">*/;
                                 };
                                 /*%FSM</LINK>*/

--- a/scripts/DAPS/Scripts/APS/fn_APSlight.fsm
+++ b/scripts/DAPS/Scripts/APS/fn_APSlight.fsm
@@ -100,7 +100,7 @@ class FSM
                                         priority = 0.000000;
                                         to="Trigger";
                                         precondition = /*%FSM<CONDPRECONDITION""">*/""/*%FSM</CONDPRECONDITION""">*/;
-                                        condition=/*%FSM<CONDITION""">*/"(count (nearestObjects [_v, [""R_MRAAWS_HE_F"", ""R_MRAAWS_HEAT_F"", ""R_MRAAWS_HEAT55_F"", ""R_TBG32V_F"", ""R_PG32V_F"", ""R_PG7_F"", ""M_NLAW_AT_F""], 125])) > 0 && {_v call DAPS_fnc_active};"/*%FSM</CONDITION""">*/;
+                                        condition=/*%FSM<CONDITION""">*/"((_v nearObjects [""MissileCore"", 125]) findIf { (typeOf _x) in [""R_MRAAWS_HE_F"", ""R_MRAAWS_HEAT_F"", ""R_MRAAWS_HEAT55_F"", ""R_TBG32V_F"", ""R_PG32V_F"", ""R_PG7_F""] } > -1 || count (_v nearObjects [""M_NLAW_AT_F"", 125]) > 0) && {_v call DAPS_fnc_active};"/*%FSM</CONDITION""">*/;
                                         action=/*%FSM<ACTION""">*/""/*%FSM</ACTION""">*/;
                                 };
                                 /*%FSM</LINK>*/

--- a/scripts/DAPS/Scripts/APS/fn_APSmedium.fsm
+++ b/scripts/DAPS/Scripts/APS/fn_APSmedium.fsm
@@ -100,7 +100,7 @@ class FSM
                                         priority = 0.000000;
                                         to="Trigger";
                                         precondition = /*%FSM<CONDPRECONDITION""">*/""/*%FSM</CONDPRECONDITION""">*/;
-                                        condition=/*%FSM<CONDITION""">*/"(count (nearestObjects [_v, [""R_TBG32V_F"", ""M_AT"", ""M_PG_AT"", ""M_Scalpel_AT"", ""M_Scalpel_AT_hidden"", ""M_SPG9_HE"", ""M_SPG9_HEAT"", ""M_Titan_AP"", ""M_Titan_AT"", ""M_Titan_AT_long"", ""M_Titan_AT_static"", ""M_Vorona_HE"", ""M_Vorona_HEAT"", ""Missile_AGM_01_F"", ""Missile_AGM_02_F"", ""R_MRAAWS_HE_F"", ""R_MRAAWS_HEAT_F"", ""R_MRAAWS_HEAT55_F"", ""R_PG32V_F"", ""R_PG7_F"", ""M_NLAW_AT_F""], 125])) > 0 && {_v call DAPS_fnc_active};"/*%FSM</CONDITION""">*/;
+                                        condition=/*%FSM<CONDITION""">*/"((_v nearObjects [""MissileCore"", 125]) + (_v nearObjects [""RocketCore"", 125])) findIf { (typeOf _x) in [""R_TBG32V_F"", ""M_AT"", ""M_PG_AT"", ""M_Scalpel_AT"", ""M_Scalpel_AT_hidden"", ""M_SPG9_HE"", ""M_SPG9_HEAT"", ""M_Titan_AP"", ""M_Titan_AT"", ""M_Titan_AT_long"", ""M_Titan_AT_static"", ""M_Vorona_HE"", ""M_Vorona_HEAT"", ""Missile_AGM_01_F"", ""Missile_AGM_02_F"", ""R_MRAAWS_HE_F"", ""R_MRAAWS_HEAT_F"", ""R_MRAAWS_HEAT55_F"", ""R_PG32V_F"", ""R_PG7_F"", ""M_NLAW_AT_F""] } > -1 && {_v call DAPS_fnc_active};"/*%FSM</CONDITION""">*/;
                                         action=/*%FSM<ACTION""">*/""/*%FSM</ACTION""">*/;
                                 };
                                 /*%FSM</LINK>*/


### PR DESCRIPTION
![Better performance by switching from `nearestObjects` to `nearObjects`.](https://github.com/Gamer-Dad/warlordsredux.altis/assets/5867121/22a743d4-095f-4ab7-bfe3-419e571b6a05)

Side by side profiling comparison: On the left is a vehicle with the new code. On the right is a vehicle with the old code. 

The difference is consistent. I suspect over a long match with many players, the old code's `nearestObjects` performance can only get even worse because it's going to be sorting an increasingly larger array. This code is run essentially every frame. The reason this change is faster is because `nearObjects` is not sorted, which we don't need it to be because we are just checking for presence.

Other approaches I tried:
1. Using `nearObjects` without specifying and filtering manually: this took longer.
2. Using `nearObjects` for each munition class: this took longer.
3. Using `nearEntities`: this didn't work.

I didn't bother to modify the other usage because that code only runs when APS is triggered, which is not very often.

Overall, I don't think this will be giving +10 FPS or anything like that, but it is consistently slightly better performance. It might be worth trying to profile the mission on the test server (needs Battleye to be off) to see what the real bottleneck is late game.