### PR TITLE
Fixed drone view not rendering correct distance to objective.

### DIFF
--- a/Functions/client/fn_WL2_sceneDrawHandle.sqf
+++ b/Functions/client/fn_WL2_sceneDrawHandle.sqf
@@ -14,7 +14,9 @@ addMissionEventHandler ["Draw3D", {
 			"center",
 			TRUE
 		];
-		_dist = (getPosVisual player) distance (missionNamespace getVariable format ["BIS_WL_currentTarget_%1", BIS_WL_playerSide]);
+		_droneView = getConnectedUAVUnit player;
+		_pos = getPosVisual (if (isNull(_droneView)) then { player } else { _droneView });
+		_dist = _pos distance (missionNamespace getVariable format ["BIS_WL_currentTarget_%1", BIS_WL_playerSide]);
 		_units = "m";
 		_dist = ceil _dist;
 		if (_dist > 1000) then {_dist = _dist / 100; _dist = round _dist; _dist = _dist / 10; _units = "km"};


### PR DESCRIPTION
Fixed UI issue where drone view would show in HUD the "distance between player and objective" rather than "distance between view and objective", not matching the game's waypoint marker.

Before (player is 2 km from objective):
![20230719201839_1](https://github.com/Gamer-Dad/warlordsredux.altis/assets/5867121/dad9bea7-b0a9-41a1-8a6d-405da8b2582d)

After:
![20230719201511_1](https://github.com/Gamer-Dad/warlordsredux.altis/assets/5867121/f573379c-fd81-4984-93fd-6095bd7e5d58)
