### PR TITLE
Fix drone map deletion, rare lag bugs, refactor

### DIFF
--- a/Functions/client/fn_WL2_assetMapControl.sqf
+++ b/Functions/client/fn_WL2_assetMapControl.sqf
@@ -6,80 +6,17 @@ BIS_WL_assetMapClickHandler = addMissionEventHandler ["MapSingleClick", {
 		if !(isNull BIS_WL_mapAssetTarget) then {
 			if ((BIS_WL_mapAssetTarget in WL_PLAYER_VEHS) && count crew BIS_WL_mapAssetTarget > 0) then {
 				if (getNumber (configFile >> "CfgVehicles" >> (typeOf BIS_WL_mapAssetTarget) >> "isUav") == 1) then {
-					[BIS_WL_mapAssetTarget] spawn {
-						params ["_target"];
-						_displayName = getText (configFile >> "CfgVehicles" >> (typeOf _target) >> "displayName");
-						_result = [format ["Are you sure you would like to delete: %1", _displayName], "Delete asset", true, true] call BIS_fnc_guiMessage;
-
-						if (_result) then {
-							playSound "AddItemOK";
-							[format [toUpper localize "STR_A3_WL_popup_asset_deleted", toUpper (_target getVariable "BIS_WL_iconText")], 2] spawn BIS_fnc_WL2_smoothText;
-							_ownedVehiclesVarName = format ["BIS_WL_%1_ownedVehicles", getPlayerUID player];
-							missionNamespace setVariable [_ownedVehiclesVarName, WL_PLAYER_VEHS - [_target]];
-							publicVariableServer _ownedVehiclesVarName;
-							if (_target isKindOf "Man") then {
-								deleteVehicle _target;
-							} else {
-								_target spawn BIS_fnc_WL2_sub_deleteAsset;
-							};
-							((ctrlParent WL_CONTROL_MAP) getVariable "BIS_sectorInfoBox") ctrlShow false;
-							((ctrlParent WL_CONTROL_MAP) getVariable "BIS_sectorInfoBox") ctrlEnable true;
-						} else {
-							playSound "AddItemFailed";
-						};
-					};
+					[BIS_WL_mapAssetTarget] spawn BIS_fnc_WL2_deleteAssetFromMap;
 				} else {
 					if ((crew BIS_WL_mapAssetTarget) findIf {alive _x} != -1) then {
 						playSound "AddItemFailed";
 						[toUpper localize "STR_A3_WL_popup_asset_not_empty"] spawn BIS_fnc_WL2_smoothText;				
 					} else {
-						[BIS_WL_mapAssetTarget] spawn {
-							params ["_target"];
-							_displayName = getText (configFile >> "CfgVehicles" >> (typeOf _target) >> "displayName");
-							_result = [format ["Are you sure you would like to delete: %1", _displayName], "Delete asset", true, true] call BIS_fnc_guiMessage;
-
-							if (_result) then {
-								playSound "AddItemOK";
-								[format [toUpper localize "STR_A3_WL_popup_asset_deleted", toUpper (_target getVariable "BIS_WL_iconText")], 2] spawn BIS_fnc_WL2_smoothText;
-								_ownedVehiclesVarName = format ["BIS_WL_%1_ownedVehicles", getPlayerUID player];
-								missionNamespace setVariable [_ownedVehiclesVarName, WL_PLAYER_VEHS - [_target]];
-								publicVariableServer _ownedVehiclesVarName;
-								if (_target isKindOf "Man") then {
-									deleteVehicle _target;
-								} else {
-									_target spawn BIS_fnc_WL2_sub_deleteAsset;
-								};
-								((ctrlParent WL_CONTROL_MAP) getVariable "BIS_sectorInfoBox") ctrlShow false;
-								((ctrlParent WL_CONTROL_MAP) getVariable "BIS_sectorInfoBox") ctrlEnable true;
-							} else {
-								playSound "AddItemFailed";
-							};
-						};
+						[BIS_WL_mapAssetTarget] spawn BIS_fnc_WL2_deleteAssetFromMap;
 					};
 				};
 			} else {
-				[BIS_WL_mapAssetTarget] spawn {
-					params ["_target"];
-					_displayName = getText (configFile >> "CfgVehicles" >> (typeOf _target) >> "displayName");
-					_result = [format ["Are you sure you would like to delete: %1", _displayName], "Delete asset", true, true] call BIS_fnc_guiMessage;
-
-					if (_result) then {
-						playSound "AddItemOK";
-						[format [toUpper localize "STR_A3_WL_popup_asset_deleted", toUpper (_target getVariable "BIS_WL_iconText")], 2] spawn BIS_fnc_WL2_smoothText;
-						_ownedVehiclesVarName = format ["BIS_WL_%1_ownedVehicles", getPlayerUID player];
-						missionNamespace setVariable [_ownedVehiclesVarName, WL_PLAYER_VEHS - [_target]];
-						publicVariableServer _ownedVehiclesVarName;
-						if (_target isKindOf "Man") then {
-							deleteVehicle _target;
-						} else {
-							_target spawn BIS_fnc_WL2_sub_deleteAsset;
-						};
-						((ctrlParent WL_CONTROL_MAP) getVariable "BIS_sectorInfoBox") ctrlShow false;
-						((ctrlParent WL_CONTROL_MAP) getVariable "BIS_sectorInfoBox") ctrlEnable true;
-					} else {
-						playSound "AddItemFailed";
-					};
-				};
+				[BIS_WL_mapAssetTarget] spawn BIS_fnc_WL2_deleteAssetFromMap;
 			};
 		};
 	};
@@ -91,8 +28,8 @@ BIS_WL_assetMapHandler = addMissionEventHandler ["EachFrame", {
 	_shown = false;
 	
 	if (visibleMap) then {
-		_nearbyAssets = ((WL_CONTROL_MAP ctrlMapScreenToWorld getMousePosition) nearObjects ["All", (((ctrlMapScale WL_CONTROL_MAP) * 500) min 50) max 2]) select {(group player) == (_x getVariable ["BIS_WL_ownerAsset", grpNull])};
-		
+		_nearbyAssets = (nearestObjects [(WL_CONTROL_MAP ctrlMapScreenToWorld getMousePosition), ["All"], (((ctrlMapScale WL_CONTROL_MAP) * 500) min 50) max 2, true]) select {(group player) == (_x getVariable ["BIS_WL_ownerAsset", grpNull])};
+
 		if (count _nearbyAssets > 0) then {
 			BIS_WL_mapAssetTarget = _nearbyAssets # 0;
 			BIS_WL_assetInfoActive = true;

--- a/Functions/client/fn_WL2_deleteAssetFromMap.sqf
+++ b/Functions/client/fn_WL2_deleteAssetFromMap.sqf
@@ -1,0 +1,30 @@
+#include "..\warlords_constants.inc"
+
+params ["_target"];
+
+_displayName = getText (configFile >> "CfgVehicles" >> (typeOf _target) >> "displayName");
+_result = [format ["Are you sure you would like to delete: %1", _displayName], "Delete asset", true, true] call BIS_fnc_guiMessage;
+
+if (_result) then {
+	playSound "AddItemOK";
+	[format [toUpper localize "STR_A3_WL_popup_asset_deleted", toUpper (_target getVariable "BIS_WL_iconText")], 2] spawn BIS_fnc_WL2_smoothText;
+	_ownedVehiclesVarName = format ["BIS_WL_%1_ownedVehicles", getPlayerUID player];
+	missionNamespace setVariable [_ownedVehiclesVarName, WL_PLAYER_VEHS - [_target]];
+	publicVariableServer _ownedVehiclesVarName;
+
+	// addresses lag-related game freeze issue
+	if (_target == (getConnectedUAV player)) then {
+		player connectTerminalToUAV objNull;
+	};
+
+	if (_target isKindOf "Man") then {
+		deleteVehicle _target;
+	} else {
+		_target spawn BIS_fnc_WL2_sub_deleteAsset;
+	};
+	((ctrlParent WL_CONTROL_MAP) getVariable "BIS_sectorInfoBox") ctrlShow false;
+	((ctrlParent WL_CONTROL_MAP) getVariable "BIS_sectorInfoBox") ctrlEnable true;
+} else {
+	playSound "AddItemFailed";
+};
+						

--- a/Functions/server/fn_WL2_setOwner.sqf
+++ b/Functions/server/fn_WL2_setOwner.sqf
@@ -4,18 +4,18 @@ params ["_asset", "_sender", ["_isStatic", FALSE]];
 
 if (_asset isKindOf "Man") exitWith {};
 
-if (isMultiplayer) then {
+if (isServer) then {
 	if !(_isStatic) then {
 		waitUntil {sleep WL_TIMEOUT_SHORT; {uniform _x == "U_VirtualMan_F"} count crew _asset == 0};
 	};
 	if (count crew _asset > 0 && _isStatic) then {
 		_assetGrp = group effectiveCommander _asset;
-		while {!(_assetGrp setGroupOwner (owner _sender)) && {alive _asset}} do {
+		while { ((groupOwner _assetGrp) != (owner _sender)) && (alive _asset) } do {
 			_assetGrp setGroupOwner (owner _sender);
 			sleep WL_TIMEOUT_SHORT;
 		};
 	};
-	while {!(_asset setOwner (owner _sender)) && (owner _asset) != (owner _sender) && {alive _asset}} do {
+	while { (owner _asset) != (owner _sender) && (alive _asset) } do {
 		_asset setOwner (owner _sender);
 		sleep WL_TIMEOUT_SHORT;
 	};

--- a/functions.hpp
+++ b/functions.hpp
@@ -9,6 +9,7 @@ class CfgFunctions {
 			class WL2_cpBalance {};
     		class WL2_announcer {};
 			class WL2_assetMapControl {};
+			class WL2_deleteAssetFromMap {};
 			class WL2_forceGroupIconsFunctionality {};
 			class WL2_friendlyFireHandleClient {};
 			class WL2_groupIconClickHandle {};


### PR DESCRIPTION
1. Fixed bug where players can't delete darter drones in the air.
2. Fixed rare lag-related issue where deleting a drone actively being controlled by a player can bug out the player's game (which forces them to exit to lobby to fix) by kicking the player out of the drone when it's deleted.
3. Refactor assetMapControl to move repetitive logic out into its own function.
4. Simplify setOwner, remove an irrelevant server RPT error, and remove infinite loop for non-dedicated servers.