### PR TITLE
Addressed remote control FF bug, fix drone driver bug

### DIFF
--- a/Functions/server/fn_WL2_handleClientRequest.sqf
+++ b/Functions/server/fn_WL2_handleClientRequest.sqf
@@ -188,7 +188,6 @@ if !(isNull _sender) then {
 							};
 
 							createVehicleCrew _asset;
-							(group effectiveCommander _asset) deleteGroupWhenEmpty true;
 						} else {
 							_isPlane = (toLower getText (configFile >> "CfgVehicles" >> _class >> "simulation")) in ["airplanex", "airplane"] && !(_class isKindOf "VTOL_Base_F");
 							if (_isPlane) then {
@@ -217,7 +216,6 @@ if !(isNull _sender) then {
 									//Code to allow Both sides to use a drone of the other side. and code to allow for air drones.
 									_asset = createVehicle [_class, _pos, [], 0, "NONE"];
 									createVehicleCrew _asset;
-									(group _asset) deleteGroupWhenEmpty true;
 								} else {
 									if (isNil {((_targetPos nearObjects ["Logic", 10]) select {count (_x getVariable ["BIS_WL_runwaySpawnPosArr", []]) > 0}) # 0}) then {
 										_sector = (((BIS_WL_allSectors) select {((_x distance _targetPos) < 15)}) # 0);
@@ -255,9 +253,7 @@ if !(isNull _sender) then {
 						if (_isStatic) then {
 							if (getNumber (configFile >> "CfgVehicles" >> _class >> "isUav") == 1) then {
 								_asset = createVehicle [_class, _pos, [], 0, "NONE"];
-								_grp = (createGroup (side player));
 								createVehicleCrew _asset;
-								[_asset] joinSilent _grp;
 							} else {
 								_asset = createVehicle [_class, _pos, [], 0, "NONE"];
 								_asset setDir (direction _sender);

--- a/Functions/server/fn_WL2_setOwner.sqf
+++ b/Functions/server/fn_WL2_setOwner.sqf
@@ -8,15 +8,39 @@ if (isServer) then {
 	if !(_isStatic) then {
 		waitUntil {sleep WL_TIMEOUT_SHORT; {uniform _x == "U_VirtualMan_F"} count crew _asset == 0};
 	};
-	if (count crew _asset > 0 && _isStatic) then {
-		_assetGrp = group effectiveCommander _asset;
-		while { ((groupOwner _assetGrp) != (owner _sender)) && (alive _asset) } do {
-			_assetGrp setGroupOwner (owner _sender);
-			sleep WL_TIMEOUT_SHORT;
-		};
-	};
-	while { (owner _asset) != (owner _sender) && (alive _asset) } do {
+	if (_isStatic && count crew _asset > 0) then {
+		// hide from all players/AI/JIP, takes no damage
+		_asset hideObjectGlobal true;
+		_asset setAutonomous false;
+
+		_grp = (createGroup (side _sender));
+		waitUntil {!alive _asset || (!isNull _asset && !isNull _grp)};
+
+		_waitMessage = [
+			"Still working...",
+			"Resolving chip shortage...",
+			"Conducting last minute checks...",
+			"Fixing AI issues...",
+			"Please hold..."
+		];
+
+		"Ordering your asset. Please wait..." remoteExec ["systemChat", (owner _sender)];
+
+		waitUntil {
+			(selectRandom _waitMessage) remoteExec ["systemChat", (owner _sender)];
+			_grp setGroupOwner (owner _sender);
+			(crew _asset) joinSilent _grp;
+			// can't be too frequent or it will never complete if server lags, ~1s is generally safe
+			sleep 1;
+			!alive _asset || (groupOwner _grp == owner _sender && side (crew _asset # 0) == side _sender)};
+		
+		_asset hideObjectGlobal false;
+		_asset setAutonomous true;
+		"Asset arrived!" remoteExec ["systemChat", (owner _sender)];
+
+		_grp deleteGroupWhenEmpty true;
+
+		// this must happen last
 		_asset setOwner (owner _sender);
-		sleep WL_TIMEOUT_SHORT;
 	};
 };


### PR DESCRIPTION
Before: turrets were engaging friendly new turrets consistently.
After: turrets generally no longer engage friendly new turrets.

The `setGroupOwner` and `joinSilent` commands take a while to work. Can take up to 15-20 seconds to get the drone ready, so added some messaging to let the user know that things are still working. (There are multiple messages it randomly selects from so even if it takes a long time, chat will continue to scroll instead of being the same message repeatedly.)

Hiding the object globally makes it invisible, which is visual feedback for the user that it's still not ready. Also, the hide object has a positive side effect that even if friendly assets manage to engage the new asset in the one-second window where it is considered the enemy (there's only a split second for it to acquire it), the newly created asset takes no damage.

Re-tested drone driver and drone auto-lock bugs, both still work consistently after this.