### PR TITLE
APS check angle for interception

### DIFF
--- a/scripts/DAPS/Scripts/APS/fn_FiredProjectile.sqf
+++ b/scripts/DAPS/Scripts/APS/fn_FiredProjectile.sqf
@@ -36,8 +36,17 @@ while { _continue } do {
 				[_projectile] spawn DAPS_fnc_MisguideMissile;
 			};
 		} else {
-			_distance =_x distance _projectile;
-			if (_vehicleAPSType >= _projectileAPSType && _distance < 125 && _distance > 30) exitWith {	// blockable by aps
+			if (_vehicleAPSType >= _projectileAPSType && {
+					// distance check
+					_distance =_x distance _projectile;
+					_distance < 125 && _distance > 30
+				} && {
+					// angle check
+					_projectileVector = vectorNormalized (velocity _projectile);
+					_vectorToVehicle = (getPosASL _projectile) vectorFromTo (getPosASL _x);
+					_incomingAngle = acos (_projectileVector vectorDotProduct _vectorToVehicle);
+					_incomingAngle < 30
+				}) exitWith {	// blockable by aps
 				_continue = false;
 
 				// deduct APS charge


### PR DESCRIPTION
Limit to 30 degrees being the maximum angle between the projectile heading and vector to target, which will allow allies nearby to fire projectiles out towards the enemy.

This angle is 3D, which means it is accurate even for top-down attack projectiles. Tested to work with infantry anti-tank weapons, including Titan (top attack) and Vorona, and works with Skalpels and DAGRs. In tests, most projectiles don't even deviate by more than 1 degree in any phase of attack. This limit being 5 degrees is enough to stop all near misses I can test. 

30 is a conservative figure, which will catch anything that will land within 62.5m of the target at max APS range and 15m of the target at min APS range. It should be sufficient even in cases of extreme lag and rubberbanding.

Dazzlers still engage all projectiles regardless of angle.

![anglecheck](https://github.com/Gamer-Dad/warlordsredux.altis/assets/5867121/5ebca510-2d36-4901-afc9-321d49154cd9)
