### PR TITLE
Added back CP reward for logistics, max reward = 200 CP / 5 min (20 rewards / 5 min)

### DIFF
--- a/Functions/client/fn_WL2_killRewardClient.sqf
+++ b/Functions/client/fn_WL2_killRewardClient.sqf
@@ -27,7 +27,8 @@ _ctrl ctrlSetPosition [_displayX - (_blockW * 110), _displayY - (_blockH * 30), 
 
 switch true do {
 	case (_transport): { 
-		_ctrl ctrlSetStructuredText parseText format ["<t size='0.8' align='right' color='#add8e6'>%1</t>", localize "STR_A3_WL_supplied"];
+		_ctrl ctrlSetStructuredText parseText format ["<t size='0.8' align='right' color='#add8e6'>%1%2</t>", localize "STR_A3_WL_supplied", 
+			if (_reward > 0) then { format [" +%1CP", _reward] } else { "" }];
 	};
 	case (_unit isKindOf "Man"): { 
 		_ctrl ctrlSetStructuredText parseText format ["<t size='0.8' align='right' color='#228b22'>Enemy killed +%1CP</t>", _reward];

--- a/Functions/server/fn_WL2_handleClientRequest.sqf
+++ b/Functions/server/fn_WL2_handleClientRequest.sqf
@@ -426,7 +426,8 @@ if (_action == "unloadSupplies") exitWith {
 		serverNamespace setVariable ["BIS_WL_lastTransported", [_sendingPlayer, _traveled]];
 	};
 
-	_supplyRewardLimiter = _sender getVariable ["BIS_WL_supplyRewardLimiter", []];
+	_playerUID = getPlayerUID _sendingPlayer;
+	_supplyRewardLimiter = localNamespace getVariable [format["BIS_WL_supplyRewardLimiter_%1", _playerUID], []];
 	_currentTime = time;
 	_itemsToDelete = 0;
 	{
@@ -442,7 +443,7 @@ if (_action == "unloadSupplies") exitWith {
 	} else {
 		_supplyRewardLimiter pushBack _currentTime;
 	};
-	_sender setVariable["BIS_WL_supplyRewardLimiter", _supplyRewardLimiter];
+	localNamespace setVariable[format["BIS_WL_supplyRewardLimiter_%1", _playerUID], _supplyRewardLimiter];
 
 	// add CP if reward > 0
 	if (_reward > 0) then {


### PR DESCRIPTION
Server-side limit CP reward to getting rewarded 20 times every 5 minutes. Reward is capped at 10 CP each time. This means the maximum possible reward is capped to 200 CP every 5 minutes. 

(Players should not usually be able to get anywhere close to 10 CP per reward for logistics, because that entails traveling 10km away from a friendly airfield to resupply a sector.)