### PR TITLE
Pyrgos Fast Travel fix

### DIFF
--- a/mission.sqm
+++ b/mission.sqm
@@ -588,8 +588,8 @@ class Mission
 			dataType="Logic";
 			class PositionInfo
 			{
-				position[]={16749.688,20.367319,12678.455};
-				angles[]={0.010663962,0,0.029321531};
+				position[]={16824.635,22.375416,12714.331};
+				angles[]={0.062584557,0,6.2551923};
 			};
 			init="this setVariable [""BIS_WL_services"", [""W""]]; ";
 			id=38;
@@ -1495,12 +1495,12 @@ class Mission
 		class Item109
 		{
 			dataType="Trigger";
-			position[]={16749.688,20.410215,12674.762};
+			position[]={16826.514,22.487381,12710.167};
 			angle=1.1467338;
 			class Attributes
 			{
-				sizeA=300;
-				sizeB=300;
+				sizeA=270;
+				sizeB=270;
 			};
 			id=117;
 			type="EmptyDetectorAreaR250";


### PR DESCRIPTION
-reduced radius of Pyrgos by 15 meters
-Moved Pyrgos by roughly 15  meters to the Northwest

This pulls in the south and west fast travel zones in by roughly 30 meters getting them out of the ocean and on to the beach. Once the fast travel see solid ground to place the player on it will always place the player on the solid ground instead of in the water or on top of an object(a pier in the case of pyrgos which caused players to fall into the water)