### PR TITLE
Team switch check vs radio/chat init fix

### DIFF
--- a/Functions/client/fn_WL2_initClient.sqf
+++ b/Functions/client/fn_WL2_initClient.sqf
@@ -282,6 +282,11 @@ addMissionEventHandler ["MarkerCreated", {
 		};
 		_e;
 	}];
+	//init radio after team check 
+	enableRadio TRUE;
+	enableSentences TRUE;
+	{_x enableChannel [TRUE, TRUE]} forEach [1,2,3,4,5];
+	{_x enableChannel [FALSE, FALSE]} forEach [0]; //no global chat
 };
 
 call BIS_fnc_WL2_sub_arsenalSetup;


### PR DESCRIPTION
Legacy code:
initclient is run
 - chat settings are on by default/server settings
 - team check fail radios/chat forced disable
 - client fixes mistake and rejoins original team radio/chat are never initialized. Client then needs to leave server(possibly losing slot) to force re-run initclient.sqf
 
 pull request:
 initclient is run
 - team check fail radios/chat forced disable
 - client fixes mistake and rejoins original team radio/chat forced enabled after passing team check. Note: this will override default server settings just as the teamcheck fail code overrides server settings to disable radios