### PR TITLE
UAV`s crew kill reward fix

### DIFF
--- a/Functions/server/clientRequests/fn_orderAir.sqf
+++ b/Functions/server/clientRequests/fn_orderAir.sqf
@@ -15,6 +15,10 @@ if (_class == "B_UAV_02_dynamicLoadout_F" || _class == "B_T_UAV_03_dynamicLoadou
 		_asset = createVehicle [_class, _posFinal, [], 0, "NONE"];
 		_grp = createVehicleCrew _asset;
 		_grp deleteGroupWhenEmpty true;
+		{
+			_member = _x;
+			_member setVariable ["BIS_WL_ownerAsset", (getPlayerUID player), [2, clientOwner]];
+		} forEach units _grp;
 		_asset setDir (direction _sender);
 	} else {
 		private _sector = ((_pos nearObjects ["Logic", 10]) select {count (_x getVariable ["BIS_WL_runwaySpawnPosArr", []]) > 0}) # 0;
@@ -38,6 +42,10 @@ if (_class == "B_UAV_02_dynamicLoadout_F" || _class == "B_T_UAV_03_dynamicLoadou
 		_asset = createVehicle [_class, _spawnPos, [], 0, "NONE"];
 		_grp = createVehicleCrew _asset;
 		_grp deleteGroupWhenEmpty true;
+		{
+			_member = _x;
+			_member setVariable ["BIS_WL_ownerAsset", (getPlayerUID player), [2, clientOwner]];
+		} forEach units _grp;
 		_asset setDir _dir;
 	};
 } else {


### PR DESCRIPTION
Hello, recently I discovered an issue with drones. The problem is that when a player controls a drone from the driver's (pilot's) position, all the kills in such cases will not be counted and the player will not receive CP for them. I submitted a bug report in discord, but it was soon deleted, so I thought I could solve this problem myself. Looking at the code, I found that the issue is that the killer is a member of the drone crew, who does not belong to the player. I suggest a code fix for this.

P.S. I did a quick test and everything was ok, I hope this code doesn't break anything

Before:
![изображение](https://github.com/Gamer-Dad/warlordsredux.altis/assets/37153939/8b02c2c2-d27b-4f61-b373-77543624839a)

After:
![изображение](https://github.com/Gamer-Dad/warlordsredux.altis/assets/37153939/9307250b-f3c7-4089-92e2-fac04a3e3403)
