### PR TITLE
🎯 [WIP] Report Generator

### DIFF
--- a/functions.hpp
+++ b/functions.hpp
@@ -73,4 +73,12 @@ class CfgFunctions {
 			class SAMmaneuver {};
 		};
 	};
+	class Fxr {
+		class init
+		{
+			file = "scripts\Fxr";
+			class openReportMenu {};
+			class closeReportMenu {};
+		};
+	}
 };

--- a/scripts/Fxr/fn_closeReportMenu.sqf
+++ b/scripts/Fxr/fn_closeReportMenu.sqf
@@ -1,0 +1,10 @@
+/*
+	Description: Cleans up the chat handler on the report menu.
+*/
+
+private _ChatEHId = missionNamespace getVariable "ChatEHId";
+if (!isNil "_ChatEHId") then {
+    removeMissionEventHandler ["HandleChatMessage", _ChatEHId];
+    missionNamespace setVariable ["ChatEHId", nil];
+};
+(findDisplay 73000) closeDisplay 1;

--- a/scripts/Fxr/fn_openReportMenu.sqf
+++ b/scripts/Fxr/fn_openReportMenu.sqf
@@ -1,0 +1,67 @@
+/*
+	Author: MrThomasM (modified by fixer)
+
+	Description: Opens the Report menu.
+*/
+
+if (isNull (findDisplay 73000)) then {	
+	_display = createDialog "Fxr_ReportDialog";
+	_playerList = ((findDisplay 73000) displayCtrl 73004);
+	disableSerialization;	
+	private _players = allPlayers - entities "HeadlessClient_F"; 
+	{
+		_playerList lbAdd name _x;
+	} forEach _players;	
+
+
+	((findDisplay 73000) displayCtrl 73004) ctrlAddEventHandler ["LBSelChanged", {
+		_playerList = ((findDisplay 73000) displayCtrl 73004);
+		_name = _playerList lbText (lbCurSel _playerList);		
+					
+			private _ChatEHId = missionNamespace getVariable "ChatEHId";
+
+			if (isNil "_ChatEHId") then {
+				diag_log "isNil _ChatEHId";
+				_ChatEHId = addMissionEventHandler ["HandleChatMessage", {
+					params ["_channel", "_owner", "_from", "_text", "_person", "_name", "_strID", "_forcedDisplay", "_isPlayerMessage", "_sentenceType", "_chatMessageType"];
+					if(_channel == 16 || _channel == 17) then {
+						private _passedname = _thisArgs select 0;
+						private _regexMatches = _text regexMatch "[\s]?.*[\d]+[\s]+([\w]{32,32})[\s]{1,1}(.*)$";
+						private _hasName = [_passedname, _text] call BIS_fnc_inString;
+											
+						if(_regexMatches and _hasName) then {
+							diag_log "_regexMatches and _hasName";
+							private _r = _text regexFind ["([\w]{32})[\s]{1}(.*)$",10];
+							if(count _r > 0) then {
+								diag_log "count _r > 0";
+								private _beId   = _r select 0 select 1 select 0;
+								private _UKTime = systemTimeUTC;
+								private _lsText = format["Name[%1] beId[%2] at %3 UTC", _passedname, _beId, _UKTime];						
+								diag_log _lsText;
+								systemChat _lsText;
+								_editCtrl = ((findDisplay 73000) displayCtrl 73006);
+								if (isNull _editCtrl) then {
+									diag_log "isNull _editCtrl";
+									w = (0.20375 * safezoneW)+(pixelW * pixelGrid*16);
+									h = 0.025 * safezoneH;
+									x = (0.38836 * safezoneW + safezoneX)-(pixelW * pixelGrid*8);
+									y = (0.235 * safezoneH + safezoneY) - h;
+									_editCtrl = (findDisplay 73000) ctrlCreate ["RscEditReadOnly",73006];
+									_editCtrl ctrlSetPosition [x,y,w,h]; 							
+								};
+								_editCtrl ctrlSetText _lsText;
+								_editCtrl ctrlCommit 0;
+							};
+						};
+					};
+					false; // /let message results show up in chat
+				}, 
+				[_name]
+			];
+			missionNamespace setVariable ["ChatEHId", _ChatEHId];
+		};
+		diag_log "serverCommand #beclient players";
+		serverCommand "#beclient players";
+	}];	
+
+};

--- a/ui/controls.hpp
+++ b/ui/controls.hpp
@@ -1041,6 +1041,18 @@ class MRTM_settingsMenu
 			font = "PuristaMedium";
 			action =  "(findDisplay 8000) closeDisplay 1; 0 spawn MRTM_fnc_openDebugMenu;";
 		};
+		class MRTMReportButton: RscButtonMRTM
+		{
+			idc = 1609;
+			text = "REPORT";
+			sizeEx = "0.021 / (getResolution select 5)";
+			x = 0.6 * safezoneW + safezoneX;
+			y = 0.786 * safezoneH + safezoneY;
+			w = 0.0567187 * safezoneW;
+			h = 0.022 * safezoneH;
+			font = "PuristaMedium";
+			action =  "(findDisplay 8000) closeDisplay 1; 0 spawn Fxr_fnc_openReportMenu;";
+		};
 	};
 };
 
@@ -1413,6 +1425,85 @@ class MRTM_debugMenu
 			h = 0.022 * safezoneH;
 			font = "PuristaMedium";
 			action = "[player, (ctrlText 2002)] spawn MRTM_fnc_execCode;";
+		};
+	};
+};
+class Fxr_ReportDialog
+{
+	idd = 73000;//Idd & idc's should be replaced, temporary only until proper range is assigned.
+
+	class Controls
+	{
+		class MRTMReportBackground: IGUIBackMRTM
+		{
+			idc = 73001;
+			colorBackground[] = {0,0,0,0.75};
+			x = 0.38836 * safezoneW + safezoneX;
+			y = 0.2646 * safezoneH + safezoneY;
+			w = 0.20375 * safezoneW;
+			h = 0.517 * safezoneH;
+		};
+		class MRTMReportHeaderBackground: IGUIBackMRTM
+		{
+			idc = 73002;
+			colorBackground[] = {"(profilenamespace getvariable ['GUI_BCG_RGB_R',0.3])", "(profilenamespace getvariable ['GUI_BCG_RGB_G',0.7])", "(profilenamespace getvariable ['GUI_BCG_RGB_B',0.8])", "(profilenamespace getvariable ['GUI_BCG_RGB_A',0.7])"};
+			x = 0.38836 * safezoneW + safezoneX;
+			y = 0.235 * safezoneH + safezoneY;
+			w = 0.20375 * safezoneW;
+			h = 0.025 * safezoneH;
+		};
+		class MRTMReportHeaderTextLeft: RscStructuredTextMRTM
+		{
+			idc = 73003;
+			text = "Report menu";
+			colorBackground[] = {0,0,0,0};
+			x = 0.38836 * safezoneW + safezoneX;
+			y = 0.235 * safezoneH + safezoneY;
+			w = 0.154687 * safezoneW;
+			h = 0.033 * safezoneH;
+			class Attributes
+			{
+				font = "PuristaMedium";
+				color = "#ffffff";
+				colorLink = "#D09B43";
+				align = "left";
+				shadow = 1;
+			};
+		};
+		class MRTMReportList: RscListBoxMRTM
+		{
+			idc = 73004;
+			deletable = 0;
+			canDrag = 0;
+			color[] = {0,1,0,1};
+			type = CT_LISTBOX;
+			x = 0.38836 * safezoneW + safezoneX;
+			y = 0.265 * safezoneH + safezoneY;
+			w = 0.203981 * safezoneW;
+			h = 0.496 * safezoneH;
+			autoScrollSpeed = -1;
+			autoScrollDelay = 5;
+			autoScrollRewind = 0;
+			class ListScrollBar{
+				color[] = {1,1,1,1};
+				thumb = "\A3\ui_f\data\gui\cfg\scrollbar\thumb_ca.paa";
+				arrowFull = "\A3\ui_f\data\gui\cfg\scrollbar\arrowFull_ca.paa";
+				arrowEmpty = "\A3\ui_f\data\gui\cfg\scrollbar\arrowEmpty_ca.paa";
+				border = "\A3\ui_f\data\gui\cfg\scrollbar\border_ca.paa";
+			};
+			style = LB_TEXTURES;
+		};
+		class MRTMReportCloseButton: RscButtonMRTM
+		{
+			idc = 73005;
+			text = "CLOSE";
+			sizeEx = "0.021 / (getResolution select 5)";
+			x = 0.38836 * safezoneW + safezoneX;
+			y = 0.786 * safezoneH + safezoneY;
+			w = 0.0567187 * safezoneW;
+			h = 0.022 * safezoneH;
+			font = "PuristaMedium";
+			action = "0 spawn Fxr_fnc_closeReportMenu;0 spawn MRTM_fnc_openMenu;";
 		};
 	};
 };


### PR DESCRIPTION
Adds a report generator option to the "Settings" scroll menu. 
![Settings link](https://i.imgur.com/s25QrLB.png)
On the bottom right you can open the Report dialog
![Report button](https://i.imgur.com/etpmhi3.png)
The Report page displays the list of users.
![Report menu](https://i.imgur.com/8iHEJ9D.png)

If a username is clicked 
![Report text generated](https://i.imgur.com/Lyh8l92.png) an eventhandler is created and the "#beclient players" servercommand is sent. The event handler receives the repsonse messages line by line. It checks if the message corresponds to a line which includes the clicked players name and it crops the players BE ID from it. In this case a message is created in a select-only box including the name, BE ID and servertime. Format: `Name[%1] beId[%2] at %3 UTC`

TODO(s): 
- [ ] set final placement of the report menu button
- [ ] Replace UI IDD/IDC-s
- [x] filter for system chat messages only
- [ ] Remove diag_log statements for testing