### PR TITLE
Fixed order in progress bug

### DIFF
--- a/Functions/client/fn_WL2_orderAircraft.sqf
+++ b/Functions/client/fn_WL2_orderAircraft.sqf
@@ -2,7 +2,12 @@
 
 params ["_class", "_cost", "_requirements"];
 
-player setVariable ["BIS_WL_isOrdering", true, [2, clientOwner]];
+/*
+Removed all refs to BIS_WL_isOrdering in this file because it was causing an error on the server "Order in progress"
+See Line 149 in purchaseMenuAssetAvailability func.
+Leaving the code as a ref if its needed again in the future. 
+*/
+//player setVariable ["BIS_WL_isOrdering", true, [2, clientOwner]];
 
 "Sector" call BIS_fnc_WL2_announcer;
 [toUpper localize "STR_A3_WL_popup_appropriate_sector_selection"] spawn BIS_fnc_WL2_smoothText;
@@ -29,7 +34,7 @@ if (BIS_WL_currentSelection == WL_ID_SELECTION_ORDERING_AIRCRAFT) then {
 if (isNull BIS_WL_targetSector) exitWith {
 	"Canceled" call BIS_fnc_WL2_announcer;
 	[toUpper localize "STR_A3_WL_deploy_canceled"] spawn BIS_fnc_WL2_smoothText;
-	player setVariable ["BIS_WL_isOrdering", false, [2, clientOwner]];
+	//player setVariable ["BIS_WL_isOrdering", false, [2, clientOwner]];
 };
 
 [toUpper localize "STR_A3_WL_asset_dispatched_TODO_REWRITE"] spawn BIS_fnc_WL2_smoothText;

--- a/Functions/client/fn_WL2_orderDefence.sqf
+++ b/Functions/client/fn_WL2_orderDefence.sqf
@@ -2,7 +2,13 @@
 
 params ["_class", "_cost", "_offset"];
 
-player setVariable ["BIS_WL_isOrdering", true, [2, clientOwner]];
+/*
+Removed all refs to BIS_WL_isOrdering in this file because it was causing an error on the server "Order in progress"
+See Line 149 in purchaseMenuAssetAvailability func.
+Leaving the code as a ref if its needed again in the future. 
+*/
+//player setVariable ["BIS_WL_isOrdering", true, [2, clientOwner]];
+
 if (count _offset != 3) then {
 	_offset = [0, 1.5, 0];
 };
@@ -79,7 +85,7 @@ if (BIS_WL_spacePressed) then {
 } else {
 	"Canceled" call BIS_fnc_WL2_announcer;
 	[toUpper localize "STR_A3_WL_deploy_canceled"] spawn BIS_fnc_WL2_smoothText;
-	player setVariable ["BIS_WL_isOrdering", false, [2, clientOwner]];
+	//player setVariable ["BIS_WL_isOrdering", false, [2, clientOwner]];
 };
 
 if (BIS_WL_currentSelection == WL_ID_SELECTION_DEPLOYING_DEFENCE) then {

--- a/Functions/client/fn_WL2_orderVehicle.sqf
+++ b/Functions/client/fn_WL2_orderVehicle.sqf
@@ -1,13 +1,18 @@
 params ["_class", "_cost"];
 
-player setVariable ["BIS_WL_isOrdering", true, [2, clientOwner]];
+/*
+Removed all refs to BIS_WL_isOrdering in this file because it was causing an error on the server "Order in progress"
+See Line 149 in purchaseMenuAssetAvailability func.
+Leaving the code as a ref if its needed again in the future. 
+*/
+//player setVariable ["BIS_WL_isOrdering", true, [2, clientOwner]];
 
 if (_class isKindOf "Man") then {
 	_asset = (group player) createUnit [_class, (getPosATL player), [], 2, "NONE"];
 	_asset setVariable ["BIS_WL_ownerAsset", getPlayerUID player, [2, clientOwner]];
 	[player, "orderAI", _class] remoteExec ["BIS_fnc_WL2_handleClientRequest", 2];
 	[_asset, player] spawn BIS_fnc_WL2_newAssetHandle;
-	player setVariable ["BIS_WL_isOrdering", false, [2, clientOwner]];
+	//player setVariable ["BIS_WL_isOrdering", false, [2, clientOwner]];
 } else {
 	BIS_WL_currentSelection = 9;
 
@@ -77,7 +82,7 @@ if (_class isKindOf "Man") then {
 	} else {
 		"Canceled" call BIS_fnc_WL2_announcer;
 		[toUpper localize "STR_A3_WL_deploy_canceled"] spawn BIS_fnc_WL2_smoothText;
-		player setVariable ["BIS_WL_isOrdering", false, [2, clientOwner]];
+		//player setVariable ["BIS_WL_isOrdering", false, [2, clientOwner]];
 	};
 
 	if (BIS_WL_currentSelection == 9) then {

--- a/Functions/server/clientRequests/fn_orderAir.sqf
+++ b/Functions/server/clientRequests/fn_orderAir.sqf
@@ -118,4 +118,9 @@ _asset enableWeaponDisassembly false;
 _owner = owner _sender;
 _asset setVariable ["BIS_WL_ownerAsset", (getPlayerUID _sender), [2, _owner]];
 [_asset, _sender] remoteExec ["BIS_fnc_WL2_newAssetHandle", _owner];
-_sender setVariable ["BIS_WL_isOrdering", false, [2, _owner]];
+//_sender setVariable ["BIS_WL_isOrdering", false, [2, _owner]];
+/*
+Removed all refs to BIS_WL_isOrdering in this file because it was causing an error on the server "Order in progress"
+See Line 149 in purchaseMenuAssetAvailability func.
+Leaving the code as a ref if its needed again in the future. 
+*/

--- a/Functions/server/clientRequests/fn_orderDefence.sqf
+++ b/Functions/server/clientRequests/fn_orderDefence.sqf
@@ -54,4 +54,9 @@ _asset setDir _direction;
 _owner = owner _sender;
 _asset setVariable ["BIS_WL_ownerAsset", (getPlayerUID _sender), [2, _owner]];
 [_asset, _sender] remoteExec ["BIS_fnc_WL2_newAssetHandle", _owner];
-_sender setVariable ["BIS_WL_isOrdering", false, [2, _owner]];
+//_sender setVariable ["BIS_WL_isOrdering", false, [2, _owner]];
+/*
+Removed all refs to BIS_WL_isOrdering in this file because it was causing an error on the server "Order in progress"
+See Line 149 in purchaseMenuAssetAvailability func.
+Leaving the code as a ref if its needed again in the future. 
+*/

--- a/Functions/server/clientRequests/fn_orderGround.sqf
+++ b/Functions/server/clientRequests/fn_orderGround.sqf
@@ -23,4 +23,9 @@ waitUntil {sleep 0.1; !(isNull _asset)};
 _owner = owner _sender;
 _asset setVariable ["BIS_WL_ownerAsset", (getPlayerUID _sender), [2, _owner]];
 [_asset, _sender] remoteExec ["BIS_fnc_WL2_newAssetHandle", _owner];
-_sender setVariable ["BIS_WL_isOrdering", false, [2, _owner]];
+//_sender setVariable ["BIS_WL_isOrdering", false, [2, _owner]];
+/*
+Removed all refs to BIS_WL_isOrdering in this file because it was causing an error on the server "Order in progress"
+See Line 149 in purchaseMenuAssetAvailability func.
+Leaving the code as a ref if its needed again in the future. 
+*/

--- a/Functions/server/clientRequests/fn_orderNaval.sqf
+++ b/Functions/server/clientRequests/fn_orderNaval.sqf
@@ -7,4 +7,9 @@ _asset = createVehicle [_class, (_pos vectorAdd [0,0,3]), [], 0, "CAN_COLLIDE"];
 _owner = owner _sender;
 _asset setVariable ["BIS_WL_ownerAsset", (getPlayerUID _sender), [2, _owner]];
 [_asset, _sender] remoteExec ["BIS_fnc_WL2_newAssetHandle", _owner];
-_sender setVariable ["BIS_WL_isOrdering", false, [2, _owner]];
+//_sender setVariable ["BIS_WL_isOrdering", false, [2, _owner]];
+/*
+Removed all refs to BIS_WL_isOrdering in this file because it was causing an error on the server "Order in progress"
+See Line 149 in purchaseMenuAssetAvailability func.
+Leaving the code as a ref if its needed again in the future. 
+*/

--- a/Functions/subroutines/fn_WL2_sub_purchaseMenuAssetAvailability.sqf
+++ b/Functions/subroutines/fn_WL2_sub_purchaseMenuAssetAvailability.sqf
@@ -146,7 +146,8 @@ if (_ret) then {
 			if (_category in ["Infantry", "Vehicles", "Gear", "Defences", "Aircraft", "Naval"] && {_nearbyEnemies}) exitWith {_ret = false; _tooltip =  localize "STR_A3_WL_tooltip_deploy_enemies_nearby"};
 			if (_category in ["Infantry", "Vehicles", "Gear", "Defences"] && {vehicle player != player}) exitWith {_ret = false; _tooltip = localize "STR_A3_WL_fasttravel_restr3"};
 			if (_category in ["Vehicles", "Infantry", "Gear", "Defences"] && {(_visitedSectorID == -1)}) exitWith {_ret = false; _tooltip = localize "STR_A3_WL_ftVehicle_restr1"};
-			if (_category in ["Infantry", "Vehicles", "Gear", "Defences", "Aircraft", "Naval"] && {(player getVariable ["BIS_WL_isOrdering", false])}) exitWith {_ret = false; _tooltip =  "Another order is in progress!"};
+			//removed this line because no where in the code does it ever check for BIS_WL_isOrdering true. Leaving the code for ref in the future. On servers this var could get out of sync and stuck to true, which blocked ordering items
+			//if (_category in ["Infantry", "Vehicles", "Gear", "Defences", "Aircraft", "Naval"] && {(player getVariable ["BIS_WL_isOrdering", false])}) exitWith {_ret = false; _tooltip =  "Another order is in progress!"}; 
 			if (_category == "Aircraft") exitWith {
 				if (getNumber (configFile >> "CfgVehicles" >> _class >> "isUav") == 1) then {
 					if (({(unitIsUAV _x) && {alive _x}} count (missionNamespace getVariable [_var, []])) >= (getMissionConfigValue ["BIS_WL_autonomous_limit", 2])) then {


### PR DESCRIPTION
'BIS_WL_isOrdering' variable was getting out of sync and stuck to "true". 

BIS_WL_isOrdering check in the order menu was doing nothing other than blocking ordering when it got stuck to true. There was no check in the code anywhere for it to be "true" so made no sense to have it as all. 

I think it was some legacy code that was left over from earlier in dev. It is now removed. 

Dedi server code: ✅
Client side RPT: ✅
Server side RPT: ✅