### PR TITLE
Player can reset isordering by respawning

### DIFF
--- a/Functions/client/fn_WL2_clientEH.sqf
+++ b/Functions/client/fn_WL2_clientEH.sqf
@@ -59,6 +59,7 @@ player addEventHandler ["Killed", {
 	if (_connectedUAV != objNull) exitWith {
 		player connectTerminalToUAV objNull;
 	};
+	player setVariable ["BIS_WL_isOrdering", false, [2, clientOwner]];
 }];
 
 player addEventHandler ["HandleDamage", {


### PR DESCRIPTION
I can't test this fix locally, RPT doesn't throw any errors. 

Idea from today's play test. 