### PR TITLE
Map hotfix for few sectors

### DIFF
--- a/Functions/common/fn_WL2_findSpawnPositions.sqf
+++ b/Functions/common/fn_WL2_findSpawnPositions.sqf
@@ -68,7 +68,7 @@ _maxAxis = (if (!(isNil {_area # 4}) && {(_area # 4)}) then {
 
 private _areaStart = _center vectorDiff [_maxAxis, _maxAxis, 0];
 private _areaEnd = _center vectorAdd [_maxAxis, _maxAxis, 0];
-private _axisStep = if (_infantryOnly) then {20} else {40};
+private _axisStep = if (_infantryOnly) then {10} else {20};
 
 private _areaCheck = if (_rimWidth == 0) then {
 	{_this inArea _area};
@@ -93,7 +93,7 @@ for [{_axisYSpawnCheck = _areaStart # 1}, {_axisYSpawnCheck < (_areaEnd # 1)}, {
 				if !(_finalPos isEqualTo []) then {
 					_finalPos = ASLToATL _finalPos;
 					_nearObjs = _finalPos nearObjects ["AllVehicles", 6];
-					_nearMapObjs = nearestTerrainObjects [_finalPos, _blacklistedMapObjects, 10, false, true];
+					_nearMapObjs = nearestTerrainObjects [_finalPos, _blacklistedMapObjects, 6, false, true];
 					if (count _nearObjs == 0 && {count _nearMapObjs == 0}) then {
 						_finalPos set [2, 0];
 						_ret pushBack _finalPos;

--- a/Functions/common/fn_WL2_findSpawnPositions.sqf
+++ b/Functions/common/fn_WL2_findSpawnPositions.sqf
@@ -89,7 +89,7 @@ for [{_axisYSpawnCheck = _areaStart # 1}, {_axisYSpawnCheck < (_areaEnd # 1)}, {
 		_spawnCheckPos = [_axisXSpawnCheck, _axisYSpawnCheck, 0];
 		if (_spawnCheckPos call _areaCheck) then {
 			if !(isOnRoad _spawnCheckPos || surfaceIsWater _spawnCheckPos || !(_spawnCheckPos inArea BIS_WL_mapAreaArray)) then {
-				_finalPos = _spawnCheckPos isFlatEmpty [6, -1, 0.35, 6, 0, FALSE, objNull];
+				_finalPos = _spawnCheckPos isFlatEmpty [3, -1, 0.35, 6, 0, FALSE, objNull];
 				if !(_finalPos isEqualTo []) then {
 					_finalPos = ASLToATL _finalPos;
 					_nearObjs = _finalPos nearObjects ["AllVehicles", 6];

--- a/Functions/server/fn_WL2_populateSector.sqf
+++ b/Functions/server/fn_WL2_populateSector.sqf
@@ -106,6 +106,22 @@ _units = [];
 _i = 0;
 while {_i < _garrisonSize} do {
 	private _pos = selectRandom _spawnPosArr;
+	/*
+	//***Spawning Diag code, visual tool for spawn points***
+	{
+       	private _posNumber = str _x;
+    	_mrkr = createMarkerLocal [_posNumber, _x];
+		_mrkr setMarkerColorLocal "ColorRed";
+    	_mrkr setMarkerTypeLocal "loc_LetterX";
+    	_mrkr setMarkerSizeLocal [1, 1];
+    } forEach _spawnPosArr;
+	
+    private _posNumber = str _i;
+    _mrkr = createMarkerLocal [_posNumber, _pos];
+    _mrkr setMarkerTypeLocal "mil_dot_noShadow";
+    _mrkr setMarkerSizeLocal [1.5, 1.5];
+	//***end diag code block***
+	*/
 	private _newGrp = createGroup _owner;
 	private _grpSize = floor (3 + random (5 - 3));
 	private _cnt = (count allPlayers) max 1;

--- a/mission.sqm
+++ b/mission.sqm
@@ -20,10 +20,9 @@ class EditorData
 	};
 	class Camera
 	{
-		pos[]={14309.652,158.01472,15815.062};
-		dir[]={0.14310242,-0.54427063,0.82661676};
-		up[]={0.092842467,0.83890939,0.53629404};
-		aside[]={0.98534501,3.5041012e-008,-0.1705817};
+		pos[]={14424.509,31.777714,15632.765};
+		dir[]={0,-0.70710683,0.70710683};
+		up[]={0,0.70710671,0.70710683};
 	};
 };
 binarizationWanted=0;
@@ -1237,7 +1236,7 @@ class Mission
 		{
 			dataType="Trigger";
 			position[]={9198.4805,16.548729,21565.646};
-			angle=0.9311679;
+			angle=0.93116748;
 			class Attributes
 			{
 				sizeA=150;
@@ -1827,7 +1826,7 @@ class Mission
 		{
 			dataType="Trigger";
 			position[]={27051.426,21.240305,21485.328};
-			angle=3.8582067;
+			angle=3.8582065;
 			class Attributes
 			{
 				sizeA=150;
@@ -2385,23 +2384,22 @@ class Mission
 			dataType="Logic";
 			class PositionInfo
 			{
-				position[]={2276.353,95.523193,22197.17};
-				angles[]={0.066566855,0,5.9966373};
+				position[]={2318.2996,67.833397,22312.252};
+				angles[]={0.28778321,0,5.9578395};
 			};
 			init="this setVariable [""BIS_WL_name"",  ""Bomos""];";
 			id=649;
 			type="Logic";
-			atlOffset=7.6293945e-006;
 		};
 		class Item147
 		{
 			dataType="Trigger";
-			position[]={2298.595,92.319366,22203.33};
+			position[]={2336.3169,64.273109,22317.553};
 			angle=2.1149371;
 			class Attributes
 			{
-				sizeA=150;
-				sizeB=150;
+				sizeA=175;
+				sizeB=175;
 			};
 			id=650;
 			type="EmptyDetector";
@@ -8763,8 +8761,8 @@ class Mission
 			dataType="Logic";
 			class PositionInfo
 			{
-				position[]={5410.1831,76.146355,17891.043};
-				angles[]={0.050614551,0,6.2778621};
+				position[]={5430.0947,76.50106,17907.738};
+				angles[]={6.2578578,0,6.2658529};
 			};
 			init="this setVariable [""BIS_WL_name"",  ""Gori Factory""];";
 			id=1414;
@@ -8773,12 +8771,13 @@ class Mission
 		class Item309
 		{
 			dataType="Trigger";
-			position[]={5410.4731,76.656906,17903.549};
-			angle=2.2371621;
+			position[]={5438.8491,76.33004,17913.574};
+			angle=1.3089966;
 			class Attributes
 			{
-				sizeA=170;
-				sizeB=170;
+				sizeA=125;
+				sizeB=200;
+				isRectangle=1;
 			};
 			id=1415;
 			type="EmptyDetector";
@@ -8788,27 +8787,26 @@ class Mission
 			dataType="Logic";
 			class PositionInfo
 			{
-				position[]={7476.1021,171.92378,21549.547};
-				angles[]={0.014660765,0,6.1453919};
+				position[]={7354.501,195.08806,21560.395};
+				angles[]={0.28410164,0,6.05269};
 			};
 			init="this setVariable [""BIS_WL_name"",  ""Synneforos Windmill""];";
 			id=1416;
 			type="Logic";
-			atlOffset=1.5258789e-005;
 		};
 		class Item311
 		{
 			dataType="Trigger";
-			position[]={7476.3931,171.83037,21562.053};
+			position[]={7341.2529,196.66168,21568.871};
 			angle=2.2371621;
 			class Attributes
 			{
-				sizeA=150;
-				sizeB=150;
+				sizeA=100;
+				sizeB=250;
+				isRectangle=1;
 			};
 			id=1417;
 			type="EmptyDetector";
-			atlOffset=1.5258789e-005;
 		};
 		class Item312
 		{
@@ -8926,7 +8924,7 @@ class Mission
 		{
 			dataType="Trigger";
 			position[]={25418.064,30.795435,19302.289};
-			angle=3.8582067;
+			angle=3.8582065;
 			class Attributes
 			{
 				sizeA=150;
@@ -9191,7 +9189,7 @@ class Mission
 		{
 			dataType="Trigger";
 			position[]={23059.529,49.055279,7274.6079};
-			angle=3.9814093;
+			angle=3.9814076;
 			class Attributes
 			{
 				sizeA=150;
@@ -9244,7 +9242,7 @@ class Mission
 		{
 			dataType="Trigger";
 			position[]={22753.467,18.265915,13577.189};
-			angle=3.9814093;
+			angle=3.9814076;
 			class Attributes
 			{
 				sizeA=150;


### PR DESCRIPTION
Adjusted a few problem sectors in Northwest part of the map. Bomos, Gori factory, and the Windmill one. 

Tightened up the spawn code by 50%. Goal: Even a zone with bad terrain or small size should now be able to find the minimum(20) number of spawn slots for Infantry.  

Aligned the radius values for "isFlatEmpty" "nearObjects" and "nearestTerrainObjects" in the findSpawnPos script. Having unified radius values on all 3 of these should greatly simplify future debugging.

