### PR TITLE
Squad system

### DIFF
--- a/Functions/client/fn_WL2_groupIconClickHandle.sqf
+++ b/Functions/client/fn_WL2_groupIconClickHandle.sqf
@@ -18,7 +18,7 @@ private _availableSectors = (switch (BIS_WL_currentSelection) do {
 if (_sector in _availableSectors) then {
 	if(BIS_WL_currentSelection in [WL_ID_SELECTION_VOTING, WL_ID_SELECTION_VOTED]) then {
 		BIS_WL_targetVote = _sector;
-		_variableFormat = format ["BIS_WL_targetVote_%1", getPlayerUID player];
+		_variableFormat = format ["BIS_WL_targetVote_%1", getPlayerID player];
 		missionNamespace setVariable [_variableFormat, _sector];
 		publicVariableServer _variableFormat;
 		if (BIS_WL_currentSelection == WL_ID_SELECTION_VOTING) then {

--- a/Functions/client/fn_WL2_initClient.sqf
+++ b/Functions/client/fn_WL2_initClient.sqf
@@ -87,6 +87,7 @@ BIS_fnc_getLiveries = compileFinal preprocessFileLineNumbers "Functions\client\r
 BIS_fnc_rearm = compileFinal preprocessFileLineNumbers "Functions\client\rearming\fn_rearm.sqf";
 
 MRTM_fnc_settingsinit = compileFinal preprocessFileLineNumbers "scripts\MRTM\fn_settingsinit.sqf";
+BIS_fnc_squadsInitClient = compileFinal preprocessFileLineNumbers "scripts\Squads\fn_squadsInitClient.sqf";
 
 waitUntil {!isNull player && {isPlayer player}};
 
@@ -169,6 +170,8 @@ enableSentences true;
 enableEnvironment [false, true];
 
 call MRTM_fnc_settingsInit;
+call BIS_fnc_squadsInitClient;
+
 uiNamespace setVariable ["BIS_WL_purchaseMenuLastSelection", [0,0,0]];
 uiNamespace setVariable ["activeControls", []];
 uiNamespace setVariable ["control", 10000];
@@ -289,6 +292,9 @@ if !(["(EU) #11", serverName] call BIS_fnc_inString) then {
 	];
 };
 
+private _squadActionText = format ["<t color='#0000FF'>%1</t>", localize "STR_SQUADS_squads"];
+private _squadActionId = player addAction[_squadActionText, { [true] call BIS_fnc_squadsMenu }, [], -100, false, false, "", ""];
+player setUserActionText [_squadActionId, _squadActionText, "<img size='2' image='\a3\ui_f\data\igui\cfg\simpletasks\types\meet_ca.paa'/>"];
 
 0 spawn BIS_fnc_WL2_factionBasedClientInit;
 

--- a/Functions/client/fn_WL2_sceneDrawHandle.sqf
+++ b/Functions/client/fn_WL2_sceneDrawHandle.sqf
@@ -34,9 +34,13 @@ addMissionEventHandler ["Draw3D", {
 		];
 	};
 	{
+		_isInMySquad = ["isInMySquad", [getPlayerID _x]] call BIS_fnc_squadsClient;
+		_color = if (_isInMySquad) then { [0.5, 0.5, 1, 1] } else { [1, 1, 1, 1] };
+		_size = if (_isInMySquad) then { 0.05 } else { 0.03 };
+
 		drawIcon3D [
 			"A3\ui_f\data\igui\cfg\islandmap\iconplayer_ca.paa",
-			[1, 1, 1, 1],
+			_color,
 			if (vehicle _x == _x) then {
 				(_x modelToWorldVisual (_x selectionPosition "head")) vectorAdd [0,0,0.6];
 			} else {
@@ -47,7 +51,7 @@ addMissionEventHandler ["Draw3D", {
 			0,
 			name _x,
 			2,
-			0.03,
+			_size,
 			"RobotoCondensedBold",
 			"center"
 		];

--- a/Functions/client/fn_WL2_setupUI.sqf
+++ b/Functions/client/fn_WL2_setupUI.sqf
@@ -360,6 +360,7 @@ if (_displayClass == "OSD") then {
 					case "Scan": {0 spawn BIS_fnc_WL2_orderSectorScan};
 					case "FTSeized": {false spawn BIS_fnc_WL2_orderFastTravel};
 					case "FTConflict": {true spawn BIS_fnc_WL2_orderFastTravel};
+					case "FTSquadLeader": {["ftSquadLeader"] spawn BIS_fnc_squadsClient};
 					case "FundsTransfer": {call BIS_fnc_WL2_orderFundsTransfer; [player, "fundsTransferBill"] remoteExec ["BIS_fnc_WL2_handleClientRequest", 2]};
 					case "TargetReset": {"RequestMenu_close" call BIS_fnc_WL2_setupUI; [player, "targetReset"] remoteExec ["BIS_fnc_WL2_handleClientRequest", 2]};
 					case "forfeitVote": {call BIS_fnc_WL2_orderForfeit};

--- a/Functions/client/fn_WL2_targetSelectionHandleClient.sqf
+++ b/Functions/client/fn_WL2_targetSelectionHandleClient.sqf
@@ -2,85 +2,114 @@
 
 {_x setMarkerAlphaLocal 0} forEach BIS_WL_sectorLinks;
 _mostVotedVar = format ["BIS_WL_mostVoted_%1", BIS_WL_playerSide];
+_voteTallyDisplayVar = format ["BIS_WL_sectorVoteTallyDisplay_%1", BIS_WL_playerSide];
 
 while {!BIS_WL_missionEnd} do {
-	_lastTarget = WL_TARGET_FRIENDLY;
-	waitUntil {sleep 1; isNull WL_TARGET_FRIENDLY};
-	if !(isNull (uiNamespace getVariable ["BIS_WL_purchaseMenuDisplay", displayNull])) then {
-		[player, "fundsTransferCancel"] remoteExec ["BIS_fnc_WL2_handleClientRequest", 2];
-		playSound "AddItemFailed";
-	};
-	"RequestMenu_close" call BIS_fnc_WL2_setupUI;
-	BIS_WL_currentSelection = WL_ID_SELECTION_VOTING;
-	0 spawn {
-		sleep 0.1;
-		if (BIS_WL_missionEnd) exitWith {};
-		"Voting" call BIS_fnc_WL2_announcer;
-		[toUpper localize "STR_A3_WL_popup_voting"] spawn BIS_fnc_WL2_smoothText;
-		waitUntil {visibleMap || {!isNull WL_TARGET_FRIENDLY}};
-		if (visibleMap && {isNull BIS_WL_targetVote}) then {
-			"Sector" call BIS_fnc_WL2_announcer;
-			[toUpper localize "STR_A3_WL_info_voting_click"] spawn BIS_fnc_WL2_smoothText;
-		};
-	};
-	if !(isNull _lastTarget) then {
-		_t = serverTime + 3;
-		waitUntil {(_lastTarget getVariable "BIS_WL_owner") == BIS_WL_playerSide || {serverTime > _t}};
-	};
-	["client"] call BIS_fnc_WL2_updateSectorArrays;
-	_mostVotedVar spawn {
-		waitUntil {count (missionNamespace getVariable [_this, []]) > 0};
-		_data = (missionNamespace getVariable _this);
-		["voting", [(_data # 1) - (getMissionConfigValue ["BIS_WL_sectorVotingDuration", 15]), _data # 1, _this]] spawn BIS_fnc_WL2_setOSDEvent;
-	};
-	
-	"voting" spawn BIS_fnc_WL2_sectorSelectionHandle;
+	private _lastTarget = WL_TARGET_FRIENDLY;
 
-	0 spawn {
-		waitUntil {!(BIS_WL_currentSelection in [WL_ID_SELECTION_VOTING, WL_ID_SELECTION_VOTED]) || {BIS_WL_missionEnd || {BIS_WL_resetTargetSelection_client}}};
+	sleep WL_TIMEOUT_SHORT;
+	_isRegularSquadMember = ["isRegularSquadMember", [getPlayerID player]] call BIS_fnc_squadsClient;
+
+	if (!_isRegularSquadMember) then {
+		waitUntil {sleep 1; isNull WL_TARGET_FRIENDLY};
+		if !(isNull (uiNamespace getVariable ["BIS_WL_purchaseMenuDisplay", displayNull])) then {
+			[player, "fundsTransferCancel"] remoteExec ["BIS_fnc_WL2_handleClientRequest", 2];
+			playSound "AddItemFailed";
+		};
+		"RequestMenu_close" call BIS_fnc_WL2_setupUI;
 		
-		["voting", "end"] spawn BIS_fnc_WL2_sectorSelectionHandle;
-	};
-	
-	if !(isServer) then {
-		waitUntil {!isNull WL_TARGET_FRIENDLY || {BIS_WL_missionEnd || {BIS_WL_resetTargetSelection_client}}};
-	} else {
-		_pass = FALSE;
-		while {!_pass} do {
-			waitUntil {!isNull WL_TARGET_FRIENDLY || {BIS_WL_missionEnd || {BIS_WL_resetTargetSelection_client}}};
-			if (BIS_WL_resetTargetSelection_client) then {
-				sleep WL_TIMEOUT_STANDARD;
-				if (BIS_WL_resetTargetSelection_client) then {
-					_pass = TRUE;
-				};
-			} else {
-				_pass = TRUE;
+		BIS_WL_currentSelection = WL_ID_SELECTION_VOTING;
+		0 spawn {
+			sleep 0.1;
+			if (BIS_WL_missionEnd) exitWith {};
+			"Voting" call BIS_fnc_WL2_announcer;
+			[toUpper localize "STR_A3_WL_popup_voting"] spawn BIS_fnc_WL2_smoothText;
+			waitUntil {visibleMap || {!isNull WL_TARGET_FRIENDLY}};
+			if (visibleMap && {isNull BIS_WL_targetVote}) then {
+				"Sector" call BIS_fnc_WL2_announcer;
+				[toUpper localize "STR_A3_WL_info_voting_click"] spawn BIS_fnc_WL2_smoothText;
 			};
 		};
-	};
-	
-	BIS_WL_targetVote = objNull;
-	
-	if (BIS_WL_currentSelection in [WL_ID_SELECTION_VOTING, WL_ID_SELECTION_VOTED]) then {
-		BIS_WL_currentSelection = WL_ID_SELECTION_NONE;
-	};
+		if !(isNull _lastTarget) then {
+			_t = serverTime + 3;
+			waitUntil {(_lastTarget getVariable "BIS_WL_owner") == BIS_WL_playerSide || {serverTime > _t}};
+		};
+		["client"] call BIS_fnc_WL2_updateSectorArrays;
 		
-	missionNamespace setVariable [_mostVotedVar, []];
-	missionNamespace setVariable [format ["BIS_WL_targetVote_%1", getPlayerUID player], objNull];
-	
-	if (BIS_WL_resetTargetSelection_client) then {
-		BIS_WL_resetTargetSelection_client = FALSE;
-		"Reset" call BIS_fnc_WL2_announcer;
-		["voting", []] spawn BIS_fnc_WL2_setOSDEvent;
-		[toUpper localize "STR_A3_WL_voting_reset"] spawn BIS_fnc_WL2_smoothText;
-		sleep 2;
-	} else {
-		call BIS_fnc_WL2_refreshCurrentTargetData;
-		if !(BIS_WL_missionEnd) then {
-			waitUntil {sleep WL_TIMEOUT_MIN; !isNull WL_TARGET_FRIENDLY};
-			"Selected" call BIS_fnc_WL2_announcer;
-			[toUpper format [localize "STR_A3_WL_popup_voting_done", WL_TARGET_FRIENDLY getVariable "BIS_WL_name"]] spawn BIS_fnc_WL2_smoothText;
-			["client", TRUE] call BIS_fnc_WL2_updateSectorArrays;
+		_mostVotedVar spawn {
+			waitUntil {count (missionNamespace getVariable [_this, []]) > 0};
+			_data = (missionNamespace getVariable _this);
+			["voting", [(_data # 1) - (getMissionConfigValue ["BIS_WL_sectorVotingDuration", 15]), _data # 1, _this]] spawn BIS_fnc_WL2_setOSDEvent;
+		};
+		
+		"voting" spawn BIS_fnc_WL2_sectorSelectionHandle;
+
+		0 spawn {
+			waitUntil {
+				private _selectedTarget = !(BIS_WL_currentSelection in [WL_ID_SELECTION_VOTING, WL_ID_SELECTION_VOTED]);
+				private _joinedSquad = ["isRegularSquadMember", [getPlayerID player]] call BIS_fnc_squadsClient;
+
+				_selectedTarget || BIS_WL_missionEnd || BIS_WL_resetTargetSelection_client || _joinedSquad
+			};
+			
+			["voting", "end"] spawn BIS_fnc_WL2_sectorSelectionHandle;
+		};
+
+		_voteTallyDisplayVar spawn {
+			while {(BIS_WL_currentSelection in [WL_ID_SELECTION_VOTING, WL_ID_SELECTION_VOTED]) && !BIS_WL_missionEnd && !BIS_WL_resetTargetSelection_client} do {
+				hint (missionNamespace getVariable _this);
+				sleep WL_TIMEOUT_STANDARD;
+			};
+
+			hintSilent "";
+		};
+		
+		if !(isServer) then {
+			waitUntil {
+				private _selectedTarget = !isNull WL_TARGET_FRIENDLY;
+				private _joinedSquad = ["isRegularSquadMember", [getPlayerID player]] call BIS_fnc_squadsClient;
+
+				_selectedTarget || BIS_WL_missionEnd || BIS_WL_resetTargetSelection_client || _joinedSquad
+			};
+		} else {
+			_pass = FALSE;
+			while {!_pass} do {
+				waitUntil {!isNull WL_TARGET_FRIENDLY || {BIS_WL_missionEnd || {BIS_WL_resetTargetSelection_client}}};
+				
+				if (BIS_WL_resetTargetSelection_client) then {
+					sleep WL_TIMEOUT_STANDARD;
+					if (BIS_WL_resetTargetSelection_client) then {
+						_pass = TRUE;
+					};
+				} else {
+					_pass = TRUE;
+				};
+			};
+		};
+		
+		BIS_WL_targetVote = objNull;
+		
+		if (BIS_WL_currentSelection in [WL_ID_SELECTION_VOTING, WL_ID_SELECTION_VOTED]) then {
+			BIS_WL_currentSelection = WL_ID_SELECTION_NONE;
+		};
+
+		missionNamespace setVariable [_mostVotedVar, []];
+		missionNamespace setVariable [format ["BIS_WL_targetVote_%1", getPlayerID player], objNull];
+		
+		if (BIS_WL_resetTargetSelection_client) then {
+			BIS_WL_resetTargetSelection_client = FALSE;
+			"Reset" call BIS_fnc_WL2_announcer;
+			["voting", []] spawn BIS_fnc_WL2_setOSDEvent;
+			[toUpper localize "STR_A3_WL_voting_reset"] spawn BIS_fnc_WL2_smoothText;
+			sleep 2;
+		} else {
+			call BIS_fnc_WL2_refreshCurrentTargetData;
+			if !(BIS_WL_missionEnd) then {
+				waitUntil {sleep WL_TIMEOUT_MIN; !isNull WL_TARGET_FRIENDLY};
+				"Selected" call BIS_fnc_WL2_announcer;
+				[toUpper format [localize "STR_A3_WL_popup_voting_done", WL_TARGET_FRIENDLY getVariable "BIS_WL_name"]] spawn BIS_fnc_WL2_smoothText;
+				["client", TRUE] call BIS_fnc_WL2_updateSectorArrays;
+			};
 		};
 	};
 };

--- a/Functions/common/fn_WL2_parsePurchaseList.sqf
+++ b/Functions/common/fn_WL2_parsePurchaseList.sqf
@@ -182,6 +182,7 @@ _strategyArr = [];
 _strategyArr pushBack ["Scan", (getMissionConfigValue ["BIS_WL_scanCost", 750]), [], localize "STR_A3_WL_param4_title", "\A3\Data_F_Warlords\Data\preview_scan.jpg", localize "STR_A3_WL_menu_scan_info"];
 _strategyArr pushBack ["FTSeized", 0, [], localize "STR_A3_WL_menu_fasttravel_seized", "\A3\Data_F_Warlords\Data\preview_ft_owned.jpg", localize "STR_A3_WL_menu_fasttravel_info"];
 _strategyArr pushBack ["FTConflict", (getMissionConfigValue ["BIS_WL_fastTravelCostContested", 200]), [], localize "STR_A3_WL_menu_fasttravel_conflict", "\A3\Data_F_Warlords\Data\preview_ft_conflict.jpg", localize "STR_A3_WL_menu_fasttravel_info"];
+_strategyArr pushBack ["FTSquadLeader", (getMissionConfigValue ["BIS_WL_fastTravelCostSquadLeader", 10]), [], localize "STR_SQUADS_fastTravelToSquadLeader", "\A3\Data_F_Warlords\Data\preview_ft_conflict.jpg", localize "STR_A3_WL_menu_fasttravel_info"];
 _strategyArr pushBack ["RespawnVicFT", 0, [], localize "STR_A3_WL_respawn_vicFT_ft", "\A3\Data_F_Warlords\Data\preview_ft_conflict.jpg", ""];
 _strategyArr pushBack ["RespawnPodFT", 0, [], "Fast Travel to Medical Pod (Free)", "\A3\Data_F_Warlords\Data\preview_ft_conflict.jpg", ""];
 _strategyArr pushBack ["RespawnVic", (getMissionConfigValue ["BIS_WL_orderFTVehicleCost", 200]), [], localize "STR_A3_WL_respawn_vicFT_order", "\A3\Data_F_Warlords\Data\preview_ft_conflict.jpg", ""];

--- a/Functions/server/fn_WL2_handleClientRequest.sqf
+++ b/Functions/server/fn_WL2_handleClientRequest.sqf
@@ -68,6 +68,14 @@ if (_action == "fastTravelContested") exitWith {
 	};
 };
 
+if (_action == "fastTravelSquadLeader") exitWith {
+	_cost = (getMissionConfigValue ["BIS_WL_fastTravelCostSquadLeader", 10]);
+	_hasFunds = (playerFunds >= _cost);
+	if (_hasFunds) then {
+		(-_cost) call BIS_fnc_WL2_fundsDatabaseWrite;
+	};
+};
+
 private _side = side group _sender;
 if (_action == "scan") exitWith {
 	_cost = (getMissionConfigValue ["BIS_WL_scanCost", 750]);

--- a/Functions/server/fn_WL2_initServer.sqf
+++ b/Functions/server/fn_WL2_initServer.sqf
@@ -52,6 +52,9 @@ MRTM_fnc_leaveGroup = compileFinal preprocessFileLineNumbers "scripts\MRTM\fn_le
 MRTM_fnc_accept = compileFinal preprocessFileLineNumbers "scripts\MRTM\fn_accept.sqf";
 MRTM_fnc_invite = compileFinal preprocessFileLineNumbers "scripts\MRTM\fn_invite.sqf";
 
+BIS_fnc_squadsInitServer = compileFinal preprocessFileLineNumbers "scripts\Squads\fn_squadsInitServer.sqf";
+call BIS_fnc_squadsInitServer;
+
 call BIS_fnc_WL2_tablesSetUp;
 call BIS_fnc_WL2_serverEHs;
 

--- a/Functions/server/fn_WL2_killRewardHandle.sqf
+++ b/Functions/server/fn_WL2_killRewardHandle.sqf
@@ -36,10 +36,23 @@ if (_killerSide != _unitSide) then {
 	if ((_targets findIf {_unit inArea (_x getVariable "objectAreaComplete")}) != -1) then {
 		_killReward = _killReward * 1.2;
 	};
-	_uid = getPlayerUID _responsibleLeader;
-	_killReward = round _killReward;
-	_killReward call BIS_fnc_WL2_fundsDatabaseWrite;
-	[_unit, _killReward] remoteExec ["BIS_fnc_WL2_killRewardClient", (owner _responsibleLeader)];
+
+	_squadmatesIDs = ["getSquadmates", [getPlayerID _responsibleLeader]] call SQUADS_API;
+	if (count _squadmatesIDs > 1) then {
+		_squadReward = round (_killReward * 1.5 / (count _squadmatesIDs));
+		{
+			_uid = getUserInfo _x # 2;
+			_squadReward call BIS_fnc_WL2_fundsDatabaseWrite;
+			[_unit, _squadReward] remoteExec ["BIS_fnc_WL2_killRewardClient", (getUserInfo _x # 1)];
+		} forEach (_squadmatesIDs);
+	} else {
+		_uid = getPlayerUID _responsibleLeader;
+		_killReward = round _killReward;
+		_killReward call BIS_fnc_WL2_fundsDatabaseWrite;
+		[_unit, _killReward] remoteExec ["BIS_fnc_WL2_killRewardClient", (owner _responsibleLeader)];
+	};
+
+	["earnPoints", [getPlayerID _responsibleLeader, _killReward]] call SQUADS_API;
 
 	_reward = round (_killReward / 4);
 	_crew = ((crew (objectParent _responsibleLeader)) select {((_x isEqualTo (gunner (objectParent _responsibleLeader))) || {(_x isEqualTo (commander (objectParent _responsibleLeader))) || {(_x isEqualTo (driver (objectParent _responsibleLeader)))}}) && {_x != _responsibleLeader && {isPlayer _x}}});

--- a/Functions/server/fn_WL2_targetSelectionHandleServer.sqf
+++ b/Functions/server/fn_WL2_targetSelectionHandleServer.sqf
@@ -7,14 +7,49 @@
 		params ["_side", "_sideIndex"];
 		_votingResetVar = format ["BIS_WL_resetTargetSelection_server_%1", _side];
 
-		_calculateMostVotedSector = {
-			_allSectorsVotedFor = [];
+		private _calculateMostVotedSector = {
+			private _warlords = allPlayers select {side group _x == _side};
+			private _players = _warlords select {isPlayer _x};
+
+			private _votesByPlayers = createHashMap;
 			{
-				_allSectorsVotedFor pushBackUnique _x;
-			} forEach _votesPool;
-			_allSectorsVotedFor = _allSectorsVotedFor apply {_sector = _x; [{_x == _sector} count _votesPool, _sector]};
-			_allSectorsVotedFor sort false;
-			(_allSectorsVotedFor # 0) # 1;
+				private _player = _x;
+				private _variableName = format ["BIS_WL_targetVote_%1", getPlayerID _player];
+				private _vote = missionNamespace getVariable [_variableName, objNull];
+				private _voteName = format ["%1", _vote];
+				if !(isNull _vote) then {
+					_voteCount = ["getSquadSizeOfSquadLeader", [getPlayerID _x]] call SQUADS_API;
+					_voteCount = _voteCount + (_votesByPlayers getOrDefault [_voteName, [objNull, 0]] select 1);
+					_votesByPlayers set [_voteName, [_vote, _voteCount]];
+				};
+			} forEach (_players select { !(["isRegularSquadMember", [getPlayerID _x]] call SQUADS_API) });
+
+			private _sortedVoteList = (toArray _votesByPlayers) # 1; // discard keys
+			_sortedVoteList = [_sortedVoteList, [], { _x # 1  }, "DESCEND"] call BIS_fnc_sortBy;
+
+			private _display = "";
+			{
+				private _vote = _x # 0;
+				private _voteCount = _x # 1;
+				_display = _display + format ["%1: %2\n", _vote getVariable "BIS_WL_name", _voteCount];
+			} forEach _sortedVoteList;
+
+			private _maxVotedSector = if (count _sortedVoteList > 0) then {
+				_firstSector  = _sortedVoteList # 0;
+				_firstSector # 0 // return sector object
+			} else {
+				objNull
+			};
+
+			[_maxVotedSector, _display];
+		};
+
+		private _wipeVotes = {
+			_players = allPlayers select {side group _x == _side} select {isPlayer _x};
+			_voterVariables = _players apply {format ["BIS_WL_targetVote_%1", getPlayerID _x]};
+			{
+				missionNamespace setVariable [_x, objNull];
+			} forEach (_voterVariables);
 		};
 		
 		while {!BIS_WL_missionEnd} do {
@@ -24,15 +59,28 @@
 			_votesPool = [];
 			_npcsVoted = FALSE;
 			missionNamespace setVariable [_votingResetVar, FALSE];
-			
+			call _wipeVotes;
+
 			waitUntil {
 				sleep WL_TIMEOUT_SHORT;
 				_warlords = allPlayers select {side group _x == _side};
 				_players = _warlords select {isPlayer _x};
 				_npcs = _warlords select {!isPlayer _x};
 				_noPlayers = count (allPlayers select {(side group _x) == ([west, east] # _sideIndex)}) == 0;
-				_playerVotingVariableNames = _players apply {format ["BIS_WL_targetVote_%1", getPlayerUID _x]};
-				(missionNamespace getVariable [_votingResetVar, false]) || {((_playerVotingVariableNames findIf {!isNull (missionNamespace getVariable [_x, objNull])} != -1) || {(if (count _npcs > 0) then {if (_noPlayers) then {serverTime > _tNoPlayers} else {false}} else {false})})}
+				_playerVotingVariableNames = _players apply {format ["BIS_WL_targetVote_%1", getPlayerID _x]};
+
+				_votingReset = missionNamespace getVariable [_votingResetVar, false];
+				_playerHasVote = _playerVotingVariableNames findIf {!isNull (missionNamespace getVariable [_x, objNull])} != -1;
+				_serverTimeCondition = serverTime > _tNoPlayers;
+
+				_conditionNpcsAndNoPlayers = if (count _npcs > 0) then {
+					if (_noPlayers) then {_serverTimeCondition} else {false}
+				} else {
+					false
+				};
+
+				// Final condition
+				_votingReset || _playerHasVote || _conditionNpcsAndNoPlayers
 			};
 			
 			if !(missionNamespace getVariable [_votingResetVar, false]) then {
@@ -44,32 +92,10 @@
 					_players = _warlords select {isPlayer _x};
 					_noPlayers = count (allPlayers select {(side group _x) == ([west, east] # _sideIndex)}) == 0;
 					
-					if (!_npcsVoted && (_noPlayers)) then {
-						_npcsVoted = TRUE;
-						_npcs = _warlords select {!isPlayer _x};
-						{
-							_votesPool pushBack selectRandom ((BIS_WL_sectorsArrays # _sideIndex) # 1);
-						} forEach _npcs;
-					};
-					
-					_playerVotingVariableNames = _players apply {format ["BIS_WL_targetVote_%1", getPlayerUID _x]};
-					
-					{
-						_variableName = _x;
-						_vote = missionNamespace getVariable [_variableName, objNull];
-						if !(isNull _vote) then {
-							_i = _variablesPool find _variableName;
-							if (_i == -1) then {
-								_variablesPool pushBack _variableName;
-								_votesPool pushBack _vote;
-							} else {
-								_votesPool set [_i, _vote];
-							};
-						};
-					} forEach _playerVotingVariableNames;
-					
 					if (serverTime >= _nextUpdate) then {
-						missionNamespace setVariable [format ["BIS_WL_mostVoted_%1", _side], [call _calculateMostVotedSector, _votingEnd], TRUE];
+						_calculation = call _calculateMostVotedSector;
+						missionNamespace setVariable [format ["BIS_WL_mostVoted_%1", _side], [_calculation # 0, _votingEnd], TRUE];
+						missionNamespace setVariable [format ["BIS_WL_sectorVoteTallyDisplay_%1", _side], _calculation # 1, TRUE];
 						_nextUpdate = serverTime + WL_TIMEOUT_STANDARD;
 					};
 					
@@ -77,15 +103,17 @@
 				};
 
 				if !(missionNamespace getVariable [_votingResetVar, false]) then {
-					[_side, call _calculateMostVotedSector] call BIS_fnc_WL2_selectTarget;
-					
+					_calculation = call _calculateMostVotedSector;
+					[_side, _calculation # 0] call BIS_fnc_WL2_selectTarget;
+
+					call _wipeVotes;
+					missionNamespace setVariable [format ["BIS_WL_sectorVoteTallyDisplay_%1", _side], "", TRUE];
+
 					["server", TRUE] call BIS_fnc_WL2_updateSectorArrays;
 
 					waitUntil {sleep WL_TIMEOUT_STANDARD; isNull (missionNamespace getVariable [format ["BIS_WL_currentTarget_%1", _side], objNull])};
 				};
 			};
-			
-			{missionNamespace setVariable [_x, objNull]} forEach _variablesPool;
 		};
 	};
 } forEach [WEST, EAST];

--- a/Functions/subroutines/fn_WL2_sub_purchaseMenuAssetAvailability.sqf
+++ b/Functions/subroutines/fn_WL2_sub_purchaseMenuAssetAvailability.sqf
@@ -41,6 +41,15 @@ if (_ret) then {
 			if (BIS_WL_currentSelection == WL_ID_SELECTION_FAST_TRAVEL) exitWith {_ret = false; _tooltip = localize "STR_A3_WL_menu_resetvoting_restr1"};
 			if (_nearbyEnemies) exitWith {_ret = false; _tooltip =  localize "STR_A3_WL_fasttravel_restr4"};
 		};
+		case "FTSquadLeader": {
+			if (vehicle player != player) exitWith {_ret = false; _tooltip = localize "STR_A3_WL_fasttravel_restr3"};
+			if (_nearbyEnemies) exitWith {_ret = false; _tooltip =  localize "STR_A3_WL_fasttravel_restr4"};
+			private _sl = ['getMySquadLeader'] call BIS_fnc_squadsClient;
+			if (_sl == getPlayerID player) exitWith {_ret = false; _tooltip = localize "STR_SQUADS_fastTravelSquadLeaderInvalid"};
+			if (_sl == "-1") exitWith {_ret = false; _tooltip = localize "STR_SQUADS_fastTravelSquadInvalidNoSquad"};
+			private _squadLeader = allPlayers select {getPlayerID _x == _sl} select 0;
+			if (!alive _squadLeader) exitWith {_ret = false; _tooltip = localize "STR_SQUADS_fastTravelSquadLeaderUnavailable"};
+		};
 		case "LastLoadout": {
 			if (vehicle player != player) exitWith {_ret = false; _tooltip = localize "STR_A3_WL_fasttravel_restr3"};
 			if (count BIS_WL_lastLoadout == 0) exitWith {_ret = false; _tooltip = localize "STR_A3_WL_no_loadout_saved"};

--- a/description.ext
+++ b/description.ext
@@ -1,6 +1,7 @@
 #include "Functions\warlords_constants.inc"
 #include "ui\defines.hpp"
 #include "ui\controls.hpp"
+#include "ui\squadMenu.hpp"
 #include "scripts\GOM\dialogs\GOM_dialog_parents.hpp"
 #include "scripts\GOM\dialogs\GOM_dialog_controls.hpp"
 
@@ -25,6 +26,7 @@ BIS_WL_sectorResetTimeout = 300;
 BIS_WL_sectorVotingDuration = 15;
 BIS_WL_scanCost = 750;
 BIS_WL_fastTravelCostContested = 200;
+BIS_WL_fastTravelCostSquadLeader = 10;
 BIS_WL_orderFTVehicleCost = 200;
 BIS_WL_fundsTransferCost = 2000;
 BIS_WL_targetResetCost = 500;

--- a/mp_securityFunctions.hpp
+++ b/mp_securityFunctions.hpp
@@ -44,6 +44,10 @@ class CfgRemoteExec {
 			allowedTargets = 0;
 		};
 
+		class SQUADS_API {
+			allowedTargets = 2;
+		};
+
 		//Don't touch
 		class BIS_fnc_effectKilledAirDestruction {allowedTargets = 0; jip = 0;};
 		class BIS_fnc_effectKilledSecondaries {allowedTargets = 0; jip = 0;};

--- a/onPlayerRespawn.sqf
+++ b/onPlayerRespawn.sqf
@@ -23,5 +23,9 @@ if !(["(EU) #11", serverName] call BIS_fnc_inString) then {
 	];
 };
 
+private _squadActionText = format ["<t color='#0000FF'>%1</t>", localize "STR_SQUADS_squads"];
+private _squadActionId = player addAction[_squadActionText, { [true] call BIS_fnc_squadsMenu }, [], -100, false, false, "", ""];
+player setUserActionText [_squadActionId, _squadActionText, "<img size='2' image='\a3\ui_f\data\igui\cfg\simpletasks\types\meet_ca.paa'/>"];
+
 player setVariable ["BIS_WL_isOrdering", false, [2, clientOwner]];
 0 spawn BIS_fnc_WL2_factionBasedClientInit;

--- a/scripts/Squads/fn_squadsClient.sqf
+++ b/scripts/Squads/fn_squadsClient.sqf
@@ -1,0 +1,202 @@
+params [
+    "_action",
+    "_params"
+];
+
+private _mySquadNumber = missionNamespace getVariable ["SQUAD_MANAGER", []] findIf {(_x select 2) find (getPlayerID player) > -1};
+private _squadManager = missionNamespace getVariable ["SQUAD_MANAGER", []];
+
+private _CREATE_BUTTON = 5014;
+private _LEAVE_BUTTON = 5012;
+private _PROMOTE_BUTTON = 5013;
+private _KICK_BUTTON = 5015;
+private _PLAYER_LIST = 5006;
+private _TREE = 5005;
+
+private _RENAME_EDIT = 5103;
+private _RENAME_WINDOW = 5100;
+
+_return = nil;
+
+switch (_action) do {
+    case "create": {
+        private _squadName = format ["%1 SQUAD", toUpper (name player)];
+        private _leader = getPlayerID player;
+        private _side = side player;
+
+        ctrlShow [_CREATE_BUTTON, false];
+    
+        ["create", [_squadName, _leader, _side]] remoteExec ["SQUADS_API", 2];
+    };
+    case "leave": {
+        if (_mySquadNumber == -1) exitWith {
+            _return = 1;
+        };
+
+        ctrlShow [_LEAVE_BUTTON, false];
+
+        ["remove", [getPlayerID player]] remoteExec ["SQUADS_API", 2];
+    };
+    case "invite": {
+        if (_mySquadNumber == -1) exitWith {
+            _return = 1;
+        };
+
+        private _selection = lbCurSel _PLAYER_LIST;
+        if (isNil "_selection") exitWith {
+            _return = 1;
+        };
+
+        private _player = lbData [_PLAYER_LIST, _selection];
+        private _inviter = getPlayerID player;
+
+        ["invite", [_player, _inviter]] remoteExec ["SQUADS_API", 2];
+
+        private _playerName = lbText [_PLAYER_LIST, _selection];
+        systemChat format [localize "STR_SQUADS_sendInvitationSuccessText", _playerName];
+    };
+    case "invited": {
+        // input: inviter id
+        private _inviter = _params select 0;
+
+        private _squad = _squadManager select { (_x select 2) find _inviter > -1 } select 0;
+        if (isNil "_squad") exitWith {
+            _return = 1;
+        };
+        private _inviterName = name (allPlayers select {getPlayerID _x == _inviter} select 0);
+
+        _acceptInvite = [
+            format [localize "STR_SQUADS_receiveInvitationText", _inviterName, _squad select 0], 
+            localize "STR_SQUADS_joinSquadTitle", 
+            localize "STR_SQUADS_joinSquadAccept", 
+            localize "STR_SQUADS_joinSquadDecline"
+        ] call BIS_fnc_guiMessage;
+        
+        if (_acceptInvite) then {
+            ["add", [_inviter, getPlayerID player]] remoteExec ["SQUADS_API", 2];
+        };
+    };
+    case "promote": {
+        private _selection = tvCurSel _TREE;
+        if (isNil "_selection") exitWith {
+            _return = 1;
+        };
+
+        private _player = tvData [_TREE, _selection];
+
+        ctrlShow [_PROMOTE_BUTTON, false];
+        ctrlShow [_KICK_BUTTON, false];
+
+        ["promote", [_player]] remoteExec ["SQUADS_API", 2];
+    };
+    case "kick": {
+        private _selection = tvCurSel _TREE;
+        if (isNil "_selection") exitWith {
+            _return = 1;
+        };
+
+        private _player = tvData [_TREE, _selection];
+
+        ctrlShow [_KICK_BUTTON, false];
+
+        ["remove", [_player]] remoteExec ["SQUADS_API", 2];
+    };
+    case "isInMySquad": {
+        // input: target player id
+        private _target = _params select 0;
+
+        if (_mySquadNumber == -1) then {
+            _return = false;
+        } else {
+            _return = (((_squadManager select _mySquadNumber) select 2) find _target) > -1;
+        };
+    };
+    case "isInSquad": {
+        // input: target player id
+        private _target = _params select 0;
+        _return = _squadManager findIf {(_x select 2) find _target > -1} > -1;
+    };
+    case "getMySquadLeader": {
+        private _playerId = getPlayerID player;
+
+        private _squad = _squadManager select {(_x select 2) find _playerId > -1} select 0;
+
+        if (isNil "_squad") then {
+            _return = "-1";
+        } else {
+            private _squadLeaderID = _squad select 1;
+            _message = format ["Squad Leader of %1: %2", _playerId, _squadLeaderID];
+            _return = _squadLeaderID;
+        };
+    };
+    case "ftSquadLeader": {
+        // call this async
+        private _sl = ['getMySquadLeader'] call BIS_fnc_squadsClient;
+        private _squadLeader = allPlayers select {getPlayerID _x == _sl} select 0;
+
+        if (isNil "_squadLeader") exitWith {
+            _return = 1;
+        };
+        if (!alive _squadLeader) exitWith {
+            _return = 2;
+        };
+
+        [player, "fastTravelSquadLeader"] remoteExec ["BIS_fnc_WL2_handleClientRequest", 2];
+
+        private _destination = getPosATL _squadLeader;
+
+        titleCut ["", "BLACK OUT", 1];
+        openMap [false, false];
+
+        sleep 1;
+
+        _tagAlong = (units player) select {(_x distance2D player <= 100) && {(isNull objectParent _x) && {(alive _x) && {(_x != player) && {_x getVariable ["BIS_WL_ownerAsset", "123"] == getPlayerUID player}}}}};
+        {
+            _x setVehiclePosition [_destination, [], 5, "NONE"];
+        } forEach _tagAlong;
+        player setVehiclePosition [_destination, [], 5, "NONE"];
+
+        sleep 1;
+
+        titleCut ["", "BLACK IN", 1];
+    };
+    case "rename": {
+        if (isNull (findDisplay _RENAME_WINDOW)) then {
+            createDialog "SquadsMenu_Rename";
+        };
+
+        private _squad = _squadManager select _mySquadNumber;
+        private _squadName = _squad select 0;
+        ctrlSetText [_RENAME_EDIT, _squadName];
+
+        private _RENAME_EDIT_CTRL = displayCtrl _RENAME_EDIT;
+        ctrlSetFocus _RENAME_EDIT_CTRL;
+
+        _RENAME_EDIT_CTRL ctrlSetTextSelection [0, count _squadName];
+
+        _return = true;
+    };
+    case "renamed": {
+        private _newName = ctrlText _RENAME_EDIT;
+        ["rename", [getPlayerID player, _newName]] remoteExec ["SQUADS_API", 2];
+        (findDisplay _RENAME_WINDOW) closeDisplay 1;
+    };
+    case "isRegularSquadMember": {
+        // Check if player is regular squad member
+        private _playerId = _params select 0;
+
+        private _isRegular = _squadManager findIf { (_x select 2) find _playerId > -1 && (_x select 1) != _playerId } > -1;
+
+        _message = format ["Player %1 is regular squad member: %2", _playerId, _isRegular];
+        _return = _isRegular;
+    };
+};
+
+if (isNil "_return") exitWith {
+//     0 spawn {
+//         sleep 0.5;
+//         [false] call BIS_fnc_squadsMenu;
+//     };
+};
+
+_return;

--- a/scripts/Squads/fn_squadsInitClient.sqf
+++ b/scripts/Squads/fn_squadsInitClient.sqf
@@ -1,0 +1,16 @@
+BIS_fnc_squadsMenu = compileFinal preprocessFileLineNumbers "scripts\Squads\fn_squadsMenu.sqf";
+BIS_fnc_squadsClient = compileFinal preprocessFileLineNumbers "scripts\Squads\fn_squadsClient.sqf";
+BIS_fnc_squadsPlayerSelectionChanged = compileFinal preprocessFileLineNumbers "scripts\Squads\fn_squadsPlayerSelectionChanged.sqf";
+BIS_fnc_squadsSquadTreeSelectionChanged = compileFinal preprocessFileLineNumbers "scripts\Squads\fn_squadsSquadTreeSelectionChanged.sqf";
+
+0 spawn {
+    _playerID = getPlayerID player;
+    while {true} do {
+        // if we REALLY want to funnel people into squads, we can change this to side chat (ch1)
+        if (getPlayerChannel player == 3 && !(["isInSquad", [_playerID]] call BIS_fnc_squadsClient)) then {
+            [true] call BIS_fnc_squadsMenu;
+        };
+    
+        sleep 1;
+    };
+};

--- a/scripts/Squads/fn_squadsInitServer.sqf
+++ b/scripts/Squads/fn_squadsInitServer.sqf
@@ -1,0 +1,42 @@
+if (isNil "SQUAD_MANAGER") then {
+    SQUAD_MANAGER = [];
+    // Structure:
+    // [Squad Name, Leader, [Members], Side]
+};
+missionNamespace setVariable ["SQUAD_MANAGER", SQUAD_MANAGER, true];
+
+if (isNil "WL_PlayerSquadContribution") then {
+    WL_PlayerSquadContribution = createHashMap;
+};
+missionNamespace setVariable ["WL_PlayerSquadContribution", WL_PlayerSquadContribution, true];
+
+SQUADS_API = compileFinal preprocessFileLineNumbers "scripts\Squads\fn_squadsServer.sqf";
+
+// Clean up the squad manager
+0 spawn {
+    addMissionEventHandler ["PlayerDisconnected", {
+        params ["_id", "_uid", "_name", "_jip", "_owner", "_idstr"];
+        private _playerId = format ["%1", _id];
+        ["remove", [_playerId]] call SQUADS_API;
+    }];
+
+    while {true} do {
+        // clean up squads when everyone goes to the lobby
+        private _squadManager = SQUAD_MANAGER;
+        {
+            private _squad = _x;
+            private _members = _squad select 2;
+            
+            {
+                private _member = _x;
+                private _danglingSquadmate = allPlayers findIf {getPlayerID _x == _member} == -1;
+
+                if (_danglingSquadmate) then {
+                    ["remove", [_member]] call SQUADS_API;
+                };
+            } forEach _members;
+        } forEach _squadManager;
+
+        sleep 30;
+    };
+};

--- a/scripts/Squads/fn_squadsMenu.sqf
+++ b/scripts/Squads/fn_squadsMenu.sqf
@@ -1,0 +1,265 @@
+/*
+    Author: MrThomasM, Rook
+    Description: Opens the squad menu.
+*/
+
+params ["_firstStart"];
+
+if (_firstStart && isNull (findDisplay 5000)) then {
+    createDialog "SquadsMenu";
+};
+
+disableSerialization;
+
+0 spawn {
+    private _TREE = 5005;
+    private _CREATE_BUTTON = 5014;
+    private _LEAVE_BUTTON = 5012;
+    private _KICK_BUTTON = 5015;
+    private _PROMOTE_BUTTON = 5013;
+    private _RENAME_BUTTON = 5011;
+    private _PLAYER_LIST = 5006;
+
+    private _selectedSquad = [-1];
+    private _selectedPlayer = -1;
+
+    private _squadManager = missionNamespace getVariable ["SQUAD_MANAGER", []];
+    private _getSquadlist = {
+        _squadListUnordered = _squadManager select { 
+            private _squad = _x;
+            private _isNotEmpty = count (_squad select 2) > 0;
+            private _isSameSide =  _squad select 3 == side player;
+            _isNotEmpty && _isSameSide;
+        };
+
+        _mySquad = _squadListUnordered select {(_x select 2) find (getPlayerID player) > -1};
+        _mySquad + (_squadListUnordered - _mySquad);
+    };
+
+    private _squadList = call _getSquadlist;
+    private _squaddedPlayers = [];
+
+    private _treeEntries = createHashMap;
+    private _listEntries = createHashMap;
+
+    private _constructSquadTree = {
+        tvClear _TREE;
+        _treeEntries = createHashMap;
+
+        {
+            private _squad = _x;
+            private _squadItem = tvAdd [_TREE, [], _squad select 0];
+            tvSetData [_TREE, [_squadItem], format ["%1", _forEachIndex]];
+            tvSetTooltip [_TREE, [_squadItem], format [localize "STR_SQUADS_squadLeaderTooltip", name (allPlayers select {getPlayerID _x == (_squad select 1)} select 0)]];
+
+            {
+                private _playerId = _x;
+                private _player = allPlayers select {getPlayerID _x == _playerId} select 0;
+                if (isNil "_player") exitWith {};
+                private _playerName = name _player;
+
+                if (_playerId == (_squad select 1)) then {
+                    _playerName = format ["%1*", _playerName];
+                };
+
+                private _playerItem = tvAdd [_TREE, [_squadItem], _playerName];
+                tvSetData [_TREE, [_squadItem, _playerItem], format ["%1", _playerId]];
+
+                _points = WL_PlayerSquadContribution getOrDefault [_playerId, 0];
+                tvSetTooltip [_TREE, [_squadItem, _playerItem], format [localize "STR_SQUADS_squadMemberTooltip", _playerName, _points]];
+
+                _tvColor = if (_playerId == (getPlayerID player)) then { [0.4, 0.6, 1.0, 1] } else { [1, 1, 1, 1] };
+
+                private _TREE_CTRL = displayCtrl _TREE;
+                _TREE_CTRL tvSetColor [[_squadItem, _playerItem], _tvColor];
+                _TREE_CTRL tvSetSelectColor [[_squadItem, _playerItem], _tvColor];
+                _TREE_CTRL tvSetColor [[_squadItem], _tvColor];
+                _TREE_CTRL tvSetSelectColor [[_squadItem], _tvColor];
+
+                _treeEntries set [format ["%1", _playerId], [_squadItem, _playerItem]];
+            } forEach (_squad select 2);
+
+            _squaddedPlayers append (_x select 2);
+        } forEach (_squadList);
+
+        tvExpandAll _TREE;
+        tvSetCurSel [_TREE, _selectedSquad];
+
+        private _treeDisplay = displayCtrl _TREE;
+        _treeDisplay ctrlAddEventHandler ["TreeSelChanged", "_this call BIS_fnc_squadsSquadTreeSelectionChanged"];
+    };
+
+    private _constructPlayerList = {
+        lbClear _PLAYER_LIST;
+        _listEntries = createHashMap;
+
+        private _unsquaddedPlayers = allPlayers select {!(getPlayerID _x in _squaddedPlayers) && side _x == side player && _x != player};
+        {
+            private _player = _x;
+            private _playerName = name _player;
+
+            private _playerItem = lbAdd [_PLAYER_LIST, _playerName];
+            lbSetData [_PLAYER_LIST, _playerItem, format ["%1", getPlayerID _player]];
+
+            _points = WL_PlayerSquadContribution getOrDefault [getPlayerID _player, 0];
+            lbSetTooltip [_PLAYER_LIST, _playerItem, format [localize "STR_SQUADS_squadMemberTooltip", _playerName, _points]];
+
+            _listEntries set [format ["%1", getPlayerID _player], _playerItem];
+        } forEach _unsquaddedPlayers;
+
+        lbSetCurSel [_PLAYER_LIST, _selectedPlayer];
+
+        private _squadListDisplay = displayCtrl _PLAYER_LIST;
+        _squadListDisplay ctrlAddEventHandler ["LBSelChanged", "_this call BIS_fnc_squadsPlayerSelectionChanged"];
+    };
+
+    private _constructButtons = {
+        private _mySquad = _squadList select {(_x select 2) find (getPlayerID player) > -1} select 0;
+        if (isNil "_mySquad") then {
+            ctrlShow [_CREATE_BUTTON, true];
+            ctrlShow [_LEAVE_BUTTON, false];
+            ctrlShow [_RENAME_BUTTON, false];
+        } else {
+            ctrlShow [_CREATE_BUTTON, false];
+            ctrlShow [_LEAVE_BUTTON, true];
+
+            private _isSquadLeader = (getPlayerID player) == (_mySquad select 1);
+            if (_isSquadLeader) then {
+                ctrlShow [_RENAME_BUTTON, true];
+            } else {
+                ctrlShow [_RENAME_BUTTON, false];
+            };
+        };
+
+        ctrlShow [_PROMOTE_BUTTON, false];
+        ctrlShow [_KICK_BUTTON, false];
+    };
+
+    private _updatePictures = {
+        params ["_treeEntries", "_listEntries"];
+        private _TREE = 5005;
+        private _PLAYER_LIST = 5006;
+
+        private _getPictureForPlayerId = {
+            params ["_playerId"];
+            private _player = allPlayers select {getPlayerID _x == _playerId} select 0;
+
+            if (isNil "_player") exitWith {
+                ""
+            };
+
+            if (isNull (objectParent _player)) then {
+                if (!alive _player) then {
+                    "\a3\Ui_F_Curator\Data\CfgMarkers\kia_ca.paa";
+                } else {
+                    "\a3\ui_f\data\igui\cfg\simpletasks\types\rifle_ca.paa";
+                };
+            } else {
+                private _vehicle = vehicle _player;
+                getText (configFile >> "CfgVehicles" >> typeOf _vehicle >> "picture");
+            };
+        };
+
+        {
+            private _treePath = [_y select 0, _y select 1];
+            private _playerId = _x;
+
+            private _picture = [_playerId] call _getPictureForPlayerId;
+            tvSetPicture [_TREE, _treePath, _picture];
+
+            private _points = WL_PlayerSquadContribution getOrDefault [_playerId, 0];
+            tvSetTooltip [_TREE, _treePath, format [localize "STR_SQUADS_squadMemberTooltip", name (allPlayers select {getPlayerID _x == _playerId} select 0), _points]];
+        } forEach _treeEntries;
+
+        {
+            private _playerId = _x;
+            
+            private _picture = [_playerId] call _getPictureForPlayerId;
+            lbSetPicture [_PLAYER_LIST, _y, _picture];
+
+            private _points = WL_PlayerSquadContribution getOrDefault [_playerId, 0];
+            lbSetTooltip [_PLAYER_LIST, _y, format [localize "STR_SQUADS_squadMemberTooltip", name (allPlayers select {getPlayerID _x == _playerId} select 0), _points]];
+        } forEach _listEntries;
+    };
+
+    call _constructSquadTree;
+    call _constructPlayerList;
+    call _constructButtons;
+    [_treeEntries, _listEntries] spawn _updatePictures;
+    
+    private _dirtySquadManager = {
+        scopeName "checkFunction";
+        params ["_oldSquadManager", "_newSquadManager"];
+        
+        // check if the sizes are the same
+        if (count _oldSquadManager != count _newSquadManager) then {
+            true breakOut "checkFunction";
+        };
+
+        {
+            private _oldSquad = _x;
+            private _newSquad = _newSquadManager select _forEachIndex;
+
+            // check names
+            if (_oldSquad select 0 != _newSquad select 0) then {
+                true breakOut "checkFunction";
+            };
+
+            // check if the squad leader is the same
+            if (_oldSquad select 1 != _newSquad select 1) then {
+                true breakOut "checkFunction";
+            };
+
+            // check if the number of squad members are the same
+            if (count (_oldSquad select 2) != count (_newSquad select 2)) then {
+                true breakOut "checkFunction";
+            };
+
+            {
+                private _oldSquadMember = _x;
+                private _newSquadMember = (_newSquad select 2) select _forEachIndex;
+
+                // check if the squad member is the same
+                if (_oldSquadMember != _newSquadMember) then {
+                    true breakOut "checkFunction";
+                };
+            } forEach (_oldSquad select 2);
+        } forEach _oldSquadManager;
+
+        false;
+    };
+
+    private _updateLoop = 0;
+    while { !(isNull (findDisplay 5000)) } do {
+        _oldSquadManager = +_squadManager;
+
+        sleep 0.5;
+
+        _selectedSquad = tvCurSel _TREE;
+        _selectedPlayer = lbCurSel _PLAYER_LIST;
+
+        _newSquadManager = missionNamespace getVariable ["SQUAD_MANAGER", []];
+
+        // only update if the squad manager has changed
+        // or else the updates would change UI settings
+        private _dirty = [_oldSquadManager, _newSquadManager] call _dirtySquadManager;
+        if (_dirty) then {
+            _squadManager = _newSquadManager;
+            _squadList = call _getSquadlist;
+            _squaddedPlayers = [];
+
+            call _constructSquadTree;
+            call _constructPlayerList;
+            call _constructButtons;
+
+            [_treeEntries, _listEntries] spawn _updatePictures;
+        };
+
+        if (_updateLoop > 5) then {
+            _updateLoop = 0;
+            [_treeEntries, _listEntries] spawn _updatePictures;
+        } else {
+            _updateLoop = _updateLoop + 1;
+        };
+    };
+};

--- a/scripts/Squads/fn_squadsPlayerSelectionChanged.sqf
+++ b/scripts/Squads/fn_squadsPlayerSelectionChanged.sqf
@@ -1,0 +1,23 @@
+params ["_control", "_lbCurSel", "_lbSelection"];
+
+private _INVITE_BUTTON = 5010;
+
+private _playerId = _control lbData _lbCurSel;
+
+private _squadManager = missionNamespace getVariable ["SQUAD_MANAGER", []];
+private _squadList = _squadManager select {count (_x select 2) > 0};
+private _mySquad = _squadList select {(_x select 2) find (getPlayerID player) > -1} select 0;
+
+private _INVITE_BUTTON_CTRL = displayCtrl _INVITE_BUTTON;
+
+if (isNil "_playerId" || _playerId == "") exitWith {
+    ctrlEnable [_INVITE_BUTTON, false];
+    _INVITE_BUTTON_CTRL ctrlSetTooltip (localize "STR_SQUADS_noPlayerSelection");
+};
+if (isNil "_mySquad") exitWith {
+    ctrlEnable [_INVITE_BUTTON, false];
+    _INVITE_BUTTON_CTRL ctrlSetTooltip (localize "STR_SQUADS_fastTravelSquadInvalidNoSquad");
+};
+
+ctrlEnable [_INVITE_BUTTON, true];
+_INVITE_BUTTON_CTRL ctrlSetTooltip localize ("STR_SQUADS_inviteSelectedPlayer");

--- a/scripts/Squads/fn_squadsServer.sqf
+++ b/scripts/Squads/fn_squadsServer.sqf
@@ -1,0 +1,178 @@
+params [
+    "_action",
+    "_params"
+];
+
+_message = nil;
+_return = nil;
+
+switch (_action) do {
+    case "create": {
+        // Create squad with name & leader
+        private _squadName = _params select 0;
+        private _leader = _params select 1;
+        private _side = _params select 2;
+
+        private _newSquad = [_squadName, _leader, [_leader], _side];
+        SQUAD_MANAGER pushBack _newSquad;
+        
+        _message = format ["Squad %1 created by %2 on %3", _squadName, _leader, _side];
+        _return = count SQUAD_MANAGER - 1;
+    };
+    case "invite": {
+        // Invite player to squad
+        private _playerId = _params select 0;
+        private _inviter = _params select 1;
+
+        private _squad = SQUAD_MANAGER select {(_x select 2) find _inviter > -1} select 0;
+        if (isNil "_squad") exitWith {
+            _message = format ["Inviter squad for %1 not found", _inviter];
+            _return = 1;
+        };
+
+        private _userInfo = getUserInfo _playerId;
+
+        if (isNil "_userInfo" || count _userInfo < 1) exitWith {
+            _message = format ["Player %1 not found", _playerId];
+            _return = 1;
+        };
+
+        private _owner = _userInfo select 1;
+
+        ['invited', [_inviter]] remoteExec ["BIS_fnc_squadsClient", _owner];
+
+        _message = format ["%1 invited to Squad %2", _playerId, _squad];
+        _return = 0;
+    };
+    case "add": {
+        // Player join squad
+        private _inviter = _params select 0;
+        private _playerId = _params select 1;
+
+        ["remove", [_playerId]] call SQUADS_API;
+
+        private _squad = SQUAD_MANAGER select {(_x select 2) find _inviter > -1} select 0;
+        if (isNil "_squad") exitWith {
+            _message = format ["Inviter squad for %1 not found", _inviter];
+            _return = 1;
+        };
+        
+        (_squad select 2) pushBack _playerId;
+        
+        _message = format ["Player %1 joined Squad %2", _playerId, (_squad select 0)];
+        _return = _squadNumber;
+    };
+    case "remove": {
+        // Remove player from squad
+        private _playerId = _params select 0;
+        
+        private _squads = SQUAD_MANAGER select {(_x select 2) find _playerId > -1};
+
+        { 
+            private _squad = _x;
+            private _members = _squad select 2;
+            _members = _members - [_playerId];
+            _squad set [2, _members];
+
+            if (_playerId == (_squad select 1)) then {
+                _squad set [1, _squad select 2 select 0];
+            };
+        } forEach _squads;
+
+        _message = format ["Player %1 removed from all squads.", _playerId];
+        _return = 0;
+    };
+    case "promote": {
+        // Promote player to squad leader
+        private _playerId = _params select 0;
+
+        private _squad = SQUAD_MANAGER select {(_x select 2) find _playerId > -1} select 0;
+        _squad set [1, _playerId];
+
+        _message = format ["Player %1 promoted to Squad Leader of %2", _playerId, (_squad select 0)];
+        _return = 0;
+    };
+    case "getSquadmates": {
+        // Get squadmates of player
+        private _playerId = _params select 0;
+
+        private _squad = SQUAD_MANAGER select {(_x select 2) find _playerId > -1} select 0;
+        private _squadmates = if (isNil "_squad") then {[]} else {_squad select 2};
+
+        _message = format ["Squadmates of %1: %2", _playerId, _squadmates];
+        _return = _squadmates;
+    };
+    case "rename": {
+        // Rename squad
+        private _playerId = _params select 0;
+        private _newName = _params select 1;
+
+        private _squad = SQUAD_MANAGER select {(_x select 1) == _playerId} select 0;
+        if (isNil "_squad") exitWith {
+            _message = format ["Squad for player %1 not found", _playerId];
+            _return = 1;
+        };
+
+        _squad set [0, _newName];
+
+        _message = format ["Player %1 renamed squad to %2", _playerId, _newName];
+        _return = 0;
+    };
+    case "isSquadLeader": {
+        // Check if player is squad leader
+        private _playerId = _params select 0;
+
+        private _squad = SQUAD_MANAGER select {(_x select 1) == _playerId};
+        private _isLeader = !isNil "_squad";
+
+        _message = format ["Player %1 is squad leader: %2", _playerId, _isLeader];
+        _return = _isLeader;
+    };
+    case "isInASquad": {
+        // Check if player is in squad
+        private _playerId = _params select 0;
+
+        private _squad = SQUAD_MANAGER select {(_x select 2) find _playerId > -1};
+        private _isInSquad = !isNil "_squad";
+
+        _message = format ["Player %1 is in squad: %2", _playerId, _isInSquad];
+        _return = _isInSquad;
+    };
+    case "isRegularSquadMember": {
+        // Check if player is regular squad member
+        private _playerId = _params select 0;
+
+        _isRegular = ["isInASquad", [_playerId]] call SQUADS_API && !(["isSquadLeader", [_playerId]] call SQUADS_API);
+
+        _message = format ["Player %1 is regular squad member: %2", _playerId, _isRegular];
+        _return = _isRegular;
+    };
+    case "getSquadSizeOfSquadLeader": {
+        // Get squad size of squad leader
+        private _playerId = _params select 0;
+
+        private _squad = SQUAD_MANAGER select {(_x select 1) == _playerId} select 0;
+        private _squadSize = if (isNil "_squad") then {1} else {count (_squad select 2)};
+
+        _message = format ["Squad size of squad leader %1: %2", _playerId, _squadSize];
+        _return = _squadSize;
+    };
+
+    case "earnPoints": {
+        private _playerId = _params select 0;
+        private _points = _params select 1;
+
+        _oldPoints = WL_PlayerSquadContribution getOrDefault [_playerId, 0];
+        _points = _points + _oldPoints;
+        WL_PlayerSquadContribution set [_playerId, _points];
+
+        missionNamespace setVariable ["WL_PlayerSquadContribution", WL_PlayerSquadContribution, true];
+
+        _message = format ["Player %1 earned %2 points", _playerId, _points];
+        _return = 0;
+    };
+};
+
+missionNamespace setVariable ["SQUAD_MANAGER", SQUAD_MANAGER, true];
+
+_return;

--- a/scripts/Squads/fn_squadsSquadTreeSelectionChanged.sqf
+++ b/scripts/Squads/fn_squadsSquadTreeSelectionChanged.sqf
@@ -1,0 +1,27 @@
+params ["_control", "_selectionPath"];
+
+private _TREE = 5005;
+private _PROMOTE_BUTTON = 5013;
+private _KICK_BUTTON = 5015;
+
+private _squadManager = missionNamespace getVariable ["SQUAD_MANAGER", []];
+private _squadList = _squadManager select {count (_x select 2) > 0};
+private _mySquad = _squadList select {(_x select 2) find (getPlayerID player) > -1} select 0;
+
+if (isNil "_mySquad") exitWith {
+    ctrlEnable [_PROMOTE_BUTTON, false];
+    ctrlEnable [_KICK_BUTTON, false];
+};
+
+private _isSquadLeader = (getPlayerID player) == (_mySquad select 1);
+
+private _selectedPlayer = _control tvData _selectionPath;
+private _isSelectedPlayerInSquad = (_mySquad select 2) find _selectedPlayer > -1;
+
+if (_isSquadLeader && _isSelectedPlayerInSquad && _selectedPlayer != (getPlayerID player)) then {
+    ctrlShow [_PROMOTE_BUTTON, true];
+    ctrlShow [_KICK_BUTTON, true];
+} else {
+    ctrlShow [_PROMOTE_BUTTON, false];
+    ctrlShow [_KICK_BUTTON, false];
+};

--- a/stringtable.xml
+++ b/stringtable.xml
@@ -1075,5 +1075,485 @@
             <Chinesesimp></Chinesesimp>
             <Chinese></Chinese>
         </Key>
+        <Key ID="STR_SQUADS_fastTravelToSquadLeader">
+            <Original>Fast Travel to Squad Leader</Original>
+            <English>Fast Travel to Squad Leader</English>
+            <Czech>Rychlé cestování k veliteli jednotky</Czech>
+            <French>Voyage rapide vers le chef d'escouade</French>
+            <German>Schnellreise zum Truppführer</German>
+            <Italian>Viaggio veloce al capo squadra</Italian>
+            <Polish>Szybka podróż do dowódcy drużyny</Polish>
+            <Portuguese>Viagem rápida para o líder do esquadrão</Portuguese>
+            <Russian>Быстрое перемещение к лидеру отряда</Russian>
+            <Spanish>Viaje rápido al líder del escuadrón</Spanish>
+            <Turkish>Takım Liderine Hızlı Seyahat</Turkish>
+            <Korean>분대장에게 빠른 이동</Korean>
+            <Japanese>分隊長への高速移動</Japanese>
+            <Chinesesimp>快速旅行到小队队长</Chinesesimp>
+            <Chinese>快速旅行到小隊隊長</Chinese>
+        </Key>
+        <Key ID="STR_SQUADS_fastTravelSquadLeaderInvalid">
+            <Original>You are the squad leader.</Original>
+            <English>You are the squad leader.</English>
+            <Czech>Jste velitel jednotky.</Czech>
+            <French>Vous êtes le chef d'escouade.</French>
+            <German>Du bist der Truppführer.</German>
+            <Italian>Sei il capo squadra.</Italian>
+            <Polish>Jesteś dowódcą drużyny.</Polish>
+            <Portuguese>Você é o líder do esquadrão.</Portuguese>
+            <Russian>Вы лидер отряда.</Russian>
+            <Spanish>Eres el líder del escuadrón.</Spanish>
+            <Turkish>Takım liderisin.</Turkish>
+            <Korean>당신이 분대장입니다.</Korean>
+            <Japanese>あなたは分隊長です。</Japanese>
+            <Chinesesimp>你是小队队长。</Chinesesimp>
+            <Chinese>你是小隊隊長。</Chinese>
+        </Key>
+        <Key ID="STR_SQUADS_fastTravelSquadLeaderUnavailable">
+            <Original>Your squad leader is unavailable.</Original>
+            <English>Your squad leader is unavailable.</English>
+            <Czech>Váš velitel jednotky není k dispozici.</Czech>
+            <French>Votre chef d'escouade n'est pas disponible.</French>
+            <German>Ihr Truppführer ist nicht verfügbar.</German>
+            <Italian>Il tuo capo squadra non è disponibile.</Italian>
+            <Polish>Twój dowódca drużyny jest niedostępny.</Polish>
+            <Portuguese>Seu líder do esquadrão está indisponível.</Portuguese>
+            <Russian>Ваш лидер отряда недоступен.</Russian>
+            <Spanish>Tu líder del escuadrón no está disponible.</Spanish>
+            <Turkish>Takım lideriniz mevcut değil.</Turkish>
+            <Korean>분대장이 사용할 수 없습니다.</Korean>
+            <Japanese>分隊長は利用できません。</Japanese>
+            <Chinesesimp>你的小队队长不可用。</Chinesesimp>
+            <Chinese>你的小隊隊長不可用。</Chinese>
+        </Key>
+        <Key ID="STR_SQUADS_fastTravelSquadInvalidNoSquad">
+            <Original>You are not in a squad.</Original>
+            <English>You are not in a squad.</English>
+            <Czech>Nejste v jednotce.</Czech>
+            <French>Vous n'êtes pas dans une escouade.</French>
+            <German>Du bist in keinem Trupp.</German>
+            <Italian>Non sei in una squadra.</Italian>
+            <Polish>Nie jesteś w drużynie.</Polish>
+            <Portuguese>Você não está em um esquadrão.</Portuguese>
+            <Russian>Вы не в отряде.</Russian>
+            <Spanish>No estás en un escuadrón.</Spanish>
+            <Turkish>Bir takımda değilsiniz.</Turkish>
+            <Korean>당신은 분대에 속해 있지 않습니다.</Korean>
+            <Japanese>あなたは分隊に所属していません。</Japanese>
+            <Chinesesimp>你不在小队里。</Chinesesimp>
+            <Chinese>你不在小隊裡。</Chinese>
+        </Key>
+        <Key ID="STR_SQUADS_sendInvitationSuccessText">
+            <Original>You've sent a squad join invitation to %1.</Original>
+            <English>You've sent a squad join invitation to %1.</English>
+            <Czech>Poslali jste pozvánku k připojení do družstva uživateli %1.</Czech>
+            <French>Vous avez envoyé une invitation à rejoindre l'escouade à %1.</French>
+            <German>Sie haben eine Einladung zum Beitritt zur Truppe an %1 gesendet.</German>
+            <Italian>Hai inviato un invito a unirti alla squadra a %1.</Italian>
+            <Polish>Wysłałeś zaproszenie do drużyny do %1.</Polish>
+            <Portuguese>Você enviou um convite para entrar na equipe para %1.</Portuguese>
+            <Russian>Вы отправили приглашение присоединиться к отряду %1.</Russian>
+            <Spanish>Has enviado una invitación para unirte al escuadrón a %1.</Spanish>
+            <Turkish>%1'e ekip katılma daveti gönderdiniz.</Turkish>
+            <Korean>%1에게 팀 합류 초대를 보냈습니다.</Korean>
+            <Japanese>%1に隊への参加招待を送りました。</Japanese>
+            <Chinesesimp>您已向%1发送了加入小队的邀请。</Chinesesimp>
+            <Chinese>您已向%1发送了加入小队的邀请。</Chinese>
+        </Key>
+        <Key ID="STR_SQUADS_receiveInvitationText">
+            <Original>%1 invited you to join %2.</Original>
+            <English>%1 invited you to join %2.</English>
+            <Czech>%1 vás pozval(a) do %2.</Czech>
+            <French>%1 vous a invité à rejoindre %2.</French>
+            <German>%1 hat Sie eingeladen, %2 beizutreten.</German>
+            <Italian>%1 ti ha invitato a unirti a %2.</Italian>
+            <Polish>%1 zaprosił(a) Cię do dołączenia do %2.</Polish>
+            <Portuguese>%1 convidou você para entrar no %2.</Portuguese>
+            <Russian>%1 пригласил(а) вас присоединиться к %2.</Russian>
+            <Spanish>%1 te ha invitado a unirte a %2.</Spanish>
+            <Turkish>%1 seni %2'ye katılmaya davet etti.</Turkish>
+            <Korean>%1님이 %2에 초대했습니다.</Korean>
+            <Japanese>%1が%2に招待しました。</Japanese>
+            <Chinesesimp>%1邀请您加入%2。</Chinesesimp>
+            <Chinese>%1邀请您加入%2。</Chinese>
+        </Key>
+        <Key ID="STR_SQUADS_joinSquadTitle">
+            <Original>Join Squad</Original>
+            <English>Join Squad</English>
+            <Czech>Připojit se k družstvu</Czech>
+            <French>Rejoindre l'escouade</French>
+            <German>Truppe beitreten</German>
+            <Italian>Unisciti alla squadra</Italian>
+            <Polish>Dołącz do drużyny</Polish>
+            <Portuguese>Entrar na equipe</Portuguese>
+            <Russian>Присоединиться к отряду</Russian>
+            <Spanish>Unirse al escuadrón</Spanish>
+            <Turkish>Takıma Katıl</Turkish>
+            <Korean>팀 합류</Korean>
+            <Japanese>隊に参加する</Japanese>
+            <Chinesesimp>加入小队</Chinesesimp>
+            <Chinese>加入小队</Chinese>
+        </Key>
+        <Key ID="STR_SQUADS_joinSquadAccept">
+            <Original>Accept</Original>
+            <English>Accept</English>
+            <Czech>Přijmout</Czech>
+            <French>Accepter</French>
+            <German>Annehmen</German>
+            <Italian>Accetta</Italian>
+            <Polish>Zaakceptuj</Polish>
+            <Portuguese>Aceitar</Portuguese>
+            <Russian>Принять</Russian>
+            <Spanish>Aceptar</Spanish>
+            <Turkish>Kabul Et</Turkish>
+            <Korean>수락</Korean>
+            <Japanese>承認</Japanese>
+            <Chinesesimp>接受</Chinesesimp>
+            <Chinese>接受</Chinese>
+        </Key>
+        <Key ID="STR_SQUADS_joinSquadDecline">
+            <Original>Decline</Original>
+            <English>Decline</English>
+            <Czech>Odmítnout</Czech>
+            <French>Refuser</French>
+            <German>Ablehnen</German>
+            <Italian>Rifiuta</Italian>
+            <Polish>Odrzuć</Polish>
+            <Portuguese>Recusar</Portuguese>
+            <Russian>Отклонить</Russian>
+            <Spanish>Rechazar</Spanish>
+            <Turkish>Reddet</Turkish>
+            <Korean>거절</Korean>
+            <Japanese>拒否</Japanese>
+            <Chinesesimp>拒绝</Chinesesimp>
+            <Chinese>拒绝</Chinese>
+        </Key>
+        <Key ID="STR_SQUADS_noPlayerSelection">
+            <Original>Select a player to invite.</Original>
+            <English>Select a player to invite.</English>
+            <Czech>Vyberte hráče, kterého chcete pozvat.</Czech>
+            <French>Sélectionnez un joueur à inviter.</French>
+            <German>Wählen Sie einen Spieler zum Einladen aus.</German>
+            <Italian>Seleziona un giocatore da invitare.</Italian>
+            <Polish>Wybierz gracza do zaproszenia.</Polish>
+            <Portuguese>Selecione um jogador para convidar.</Portuguese>
+            <Russian>Выберите игрока для приглашения.</Russian>
+            <Spanish>Selecciona un jugador para invitar.</Spanish>
+            <Turkish>Davet etmek için bir oyuncu seçin.</Turkish>
+            <Korean>초대할 플레이어를 선택하세요.</Korean>
+            <Japanese>招待するプレイヤーを選択してください。</Japanese>
+            <Chinesesimp>选择一个玩家邀请。</Chinesesimp>
+            <Chinese>选择一个玩家邀请。</Chinese>
+        </Key>
+        <Key ID="STR_SQUADS_inviteSelectedPlayer">
+            <Original>Invite selected player to your squad.</Original>
+            <English>Invite selected player to your squad.</English>
+            <Czech>Pozvěte vybraného hráče do svého družstva.</Czech>
+            <French>Invitez le joueur sélectionné dans votre escouade.</French>
+            <German>Laden Sie den ausgewählten Spieler in Ihre Truppe ein.</German>
+            <Italian>Invita il giocatore selezionato nella tua squadra.</Italian>
+            <Polish>Zaproś wybranego gracza do swojej drużyny.</Polish>
+            <Portuguese>Convide o jogador selecionado para sua equipe.</Portuguese>
+            <Russian>Пригласите выбранного игрока в свой отряд.</Russian>
+            <Spanish>Invita al jugador seleccionado a tu escuadrón.</Spanish>
+            <Turkish>Seçilen oyuncuyu ekibine davet et.</Turkish>
+            <Korean>선택한 플레이어를 팀에 초대하세요.</Korean>
+            <Japanese>選択したプレイヤーを隊に招待します。</Japanese>
+            <Chinesesimp>邀请选定的玩家加入你的小队。</Chinesesimp>
+            <Chinese>邀请选定的玩家加入你的小队。</Chinese>
+        </Key>
+        <Key ID="STR_SQUADS_welcomeText">
+            <Original>Welcome to the squad system. Squads confer a variety of benefits, including sharing points/votes and the ability to spawn on your squad leader.</Original>
+            <English>Welcome to the squad system. Squads confer a variety of benefits, including sharing points/votes and the ability to spawn on your squad leader.</English>
+            <Czech>Vítejte v systému družstev. Družstva poskytují řadu výhod, včetně sdílení bodů/hlasů a možnosti znovu se objevit u svého vedoucího družstva.</Czech>
+            <French>Bienvenue dans le système d'escouades. Les escouades offrent une variété d'avantages, y compris le partage de points/votes et la possibilité d'apparaître près de votre chef d'escouade.</French>
+            <German>Willkommen im Truppensystem. Truppen bieten eine Vielzahl von Vorteilen, einschließlich des Teilens von Punkten/Stimmen und der Möglichkeit, bei Ihrem Truppenführer zu spawnen.</German>
+            <Italian>Benvenuto nel sistema delle squadre. Le squadre offrono una varietà di vantaggi, tra cui la condivisione di punti/voti e la possibilità di apparire vicino al tuo capo squadra.</Italian>
+            <Polish>Witamy w systemie drużyn. Drużyny oferują wiele korzyści, w tym dzielenie się punktami/głosami oraz możliwość odrodzenia się u lidera drużyny.</Polish>
+            <Portuguese>Bem-vindo ao sistema de esquadrões. Os esquadrões oferecem uma variedade de benefícios, incluindo o compartilhamento de pontos/votos e a capacidade de nascer no seu líder de esquadrão.</Portuguese>
+            <Russian>Добро пожаловать в систему отрядов. Отряды предоставляют множество преимуществ, включая совместное использование очков/голосов и возможность возрождения рядом с вашим командиром отряда.</Russian>
+            <Spanish>Bienvenido al sistema de escuadrones. Los escuadrones confieren una variedad de beneficios, incluidos compartir puntos/votos y la capacidad de aparecer cerca de tu líder de escuadrón.</Spanish>
+            <Turkish>Takım sistemine hoş geldiniz. Takımlar, puanları/oyları paylaşma ve takım liderinizin yanında doğma yeteneği de dahil olmak üzere çeşitli avantajlar sağlar.</Turkish>
+            <Korean>팀 시스템에 오신 것을 환영합니다. 팀은 점수/투표 공유 및 팀 리더에게서 스폰할 수 있는 능력 등 다양한 혜택을 제공합니다.</Korean>
+            <Japanese>隊システムへようこそ。隊は、ポイント/投票の共有や隊長の近くでリスポーンする能力など、さまざまな利点をもたらします。</Japanese>
+            <Chinesesimp>欢迎使用小队系统。小队提供多种好处，包括共享积分/投票以及在小队队长旁重生的能力。</Chinesesimp>
+            <Chinese>欢迎使用小队系统。小队提供多种好处，包括共享积分/投票以及在小队队长旁重生的能力。</Chinese>
+        </Key>
+        <Key ID="STR_SQUADS_squadLeaderTooltip">
+            <Original>Leader: %1</Original>
+            <English>Leader: %1</English>
+            <Czech>Vedoucí: %1</Czech>
+            <French>Chef : %1</French>
+            <German>Führer: %1</German>
+            <Italian>Capo: %1</Italian>
+            <Polish>Leader: %1</Polish>
+            <Portuguese>Líder: %1</Portuguese>
+            <Russian>Лидер: %1</Russian>
+            <Spanish>Líder: %1</Spanish>
+            <Turkish>Lider: %1</Turkish>
+            <Korean>리더: %1</Korean>
+            <Japanese>リーダー: %1</Japanese>
+            <Chinesesimp>队长：%1</Chinesesimp>
+            <Chinese>队长：%1</Chinese>
+        </Key>
+        <Key ID="STR_SQUADS_squadMemberTooltip">
+            <Original>%1 (%2 points)</Original>
+            <English>%1 (%2 points)</English>
+            <Czech>%1 (%2 bodů)</Czech>
+            <French>%1 (%2 points)</French>
+            <German>%1 (%2 Punkte)</German>
+            <Italian>%1 (%2 punti)</Italian>
+            <Polish>%1 (%2 punkty)</Polish>
+            <Portuguese>%1 (%2 pontos)</Portuguese>
+            <Russian>%1 (%2 очков)</Russian>
+            <Spanish>%1 (%2 puntos)</Spanish>
+            <Turkish>%1 (%2 puan)</Turkish>
+            <Korean>%1 (%2 포인트)</Korean>
+            <Japanese>%1 (%2 ポイント)</Japanese>
+            <Chinesesimp>%1（%2分）</Chinesesimp>
+            <Chinese>%1（%2分）</Chinese>
+        </Key>
+        <Key ID="STR_SQUADS_squadMenuText">
+            <Original>Squads Menu</Original>
+            <English>Squads Menu</English>
+            <Czech>Nabídka družstev</Czech>
+            <French>Menu des escouades</French>
+            <German>Truppenmenü</German>
+            <Italian>Menu delle squadre</Italian>
+            <Polish>Menu drużyn</Polish>
+            <Portuguese>Menu de Esquadrões</Portuguese>
+            <Russian>Меню отрядов</Russian>
+            <Spanish>Menú de escuadrones</Spanish>
+            <Turkish>Takımlar Menüsü</Turkish>
+            <Korean>팀 메뉴</Korean>
+            <Japanese>隊メニュー</Japanese>
+            <Chinesesimp>小队菜单</Chinesesimp>
+            <Chinese>小队菜单</Chinese>
+        </Key>
+        <Key ID="STR_SQUADS_squadInviteMenuText">
+            <Original>Adopt a squad-less teammate:</Original>
+            <English>Adopt a squad-less teammate:</English>
+            <Czech>Adoptujte spoluhráče bez družstva:</Czech>
+            <French>Adopter un coéquipier sans escouade :</French>
+            <German>Nehmen Sie ein teamloses Mitglied auf:</German>
+            <Italian>Adotta un compagno di squadra senza squadra:</Italian>
+            <Polish>Przygarnij gracza bez drużyny:</Polish>
+            <Portuguese>Adotar um colega de equipe sem esquadrão:</Portuguese>
+            <Russian>Примите товарища по команде без отряда:</Russian>
+            <Spanish>Adopta un compañero de equipo sin escuadrón:</Spanish>
+            <Turkish>Takımsız bir takım arkadaşını al:</Turkish>
+            <Korean>팀이 없는 팀원을 받아들이세요:</Korean>
+            <Japanese>隊のないチームメイトを採用する：</Japanese>
+            <Chinesesimp>收编没有小队的队友：</Chinesesimp>
+            <Chinese>收编没有小队的队友：</Chinese>
+        </Key>
+        <Key ID="STR_SQUADS_buttonsLeave">
+            <Original>LEAVE</Original>
+            <English>LEAVE</English>
+            <Czech>OPUSTIT</Czech>
+            <French>QUITTER</French>
+            <German>VERLASSEN</German>
+            <Italian>LASCIARE</Italian>
+            <Polish>OPUŚCIĆ</Polish>
+            <Portuguese>SAIR</Portuguese>
+            <Russian>ПОКИНУТЬ</Russian>
+            <Spanish>DEJAR</Spanish>
+            <Turkish>AYRIL</Turkish>
+            <Korean>떠나다</Korean>
+            <Japanese>離れる</Japanese>
+            <Chinesesimp>离开</Chinesesimp>
+            <Chinese>离开</Chinese>
+        </Key>
+
+        <Key ID="STR_SQUADS_buttonsPromote">
+            <Original>PROMOTE</Original>
+            <English>PROMOTE</English>
+            <Czech>POVÝŠIT</Czech>
+            <French>PROMOUVOIR</French>
+            <German>BEFÖRDERN</German>
+            <Italian>PROMUOVERE</Italian>
+            <Polish>AWANSOWAĆ</Polish>
+            <Portuguese>PROMOVER</Portuguese>
+            <Russian>ПОВЫСИТЬ</Russian>
+            <Spanish>PROMOVER</Spanish>
+            <Turkish>TERFİ</Turkish>
+            <Korean>승진</Korean>
+            <Japanese>昇進</Japanese>
+            <Chinesesimp>晋升</Chinesesimp>
+            <Chinese>晋升</Chinese>
+        </Key>
+
+        <Key ID="STR_SQUADS_buttonsKick">
+            <Original>KICK</Original>
+            <English>KICK</English>
+            <Czech>VYKOPNOUT</Czech>
+            <French>EXCLURE</French>
+            <German>RAUSWERFEN</German>
+            <Italian>ESPULSARE</Italian>
+            <Polish>WYRZUCIĆ</Polish>
+            <Portuguese>EXPULSAR</Portuguese>
+            <Russian>ВЫГНАТЬ</Russian>
+            <Spanish>EXPULSAR</Spanish>
+            <Turkish>ATMAK</Turkish>
+            <Korean>내보내다</Korean>
+            <Japanese>キック</Japanese>
+            <Chinesesimp>踢出</Chinesesimp>
+            <Chinese>踢出</Chinese>
+        </Key>
+
+        <Key ID="STR_SQUADS_buttonsRename">
+            <Original>RENAME</Original>
+            <English>RENAME</English>
+            <Czech>PŘEJMENOVAT</Czech>
+            <French>RENOMMER</French>
+            <German>UMBENENNEN</German>
+            <Italian>RINOMINARE</Italian>
+            <Polish>PRZENAME</Polish>
+            <Portuguese>RENOMEAR</Portuguese>
+            <Russian>ПЕРЕИМЕНОВАТЬ</Russian>
+            <Spanish>RENOMBRAR</Spanish>
+            <Turkish>YENİDEN ADLANDIRMAK</Turkish>
+            <Korean>이름 변경</Korean>
+            <Japanese>名前を変更する</Japanese>
+            <Chinesesimp>重命名</Chinesesimp>
+            <Chinese>重命名</Chinese>
+        </Key>
+
+        <Key ID="STR_SQUADS_buttonsCreate">
+            <Original>CREATE</Original>
+            <English>CREATE</English>
+            <Czech>VYTVOŘIT</Czech>
+            <French>CRÉER</French>
+            <German>ERSTELLEN</German>
+            <Italian>CREARE</Italian>
+            <Polish>UTWÓRZ</Polish>
+            <Portuguese>CRIAR</Portuguese>
+            <Russian>СОЗДАТЬ</Russian>
+            <Spanish>CREAR</Spanish>
+            <Turkish>OLUŞTUR</Turkish>
+            <Korean>만들다</Korean>
+            <Japanese>作成</Japanese>
+            <Chinesesimp>创建</Chinesesimp>
+            <Chinese>创建</Chinese>
+        </Key>
+        <Key ID="STR_SQUADS_buttonsInvite">
+            <Original>INVITE</Original>
+            <English>INVITE</English>
+            <Czech>POZVAT</Czech>
+            <French>INVITER</French>
+            <German>EINLADEN</German>
+            <Italian>INVITARE</Italian>
+            <Polish>ZAPROSIĆ</Polish>
+            <Portuguese>CONVIDAR</Portuguese>
+            <Russian>ПРИГЛАСИТЬ</Russian>
+            <Spanish>INVITAR</Spanish>
+            <Turkish>DAVET ET</Turkish>
+            <Korean>초대</Korean>
+            <Japanese>招待</Japanese>
+            <Chinesesimp>邀请</Chinesesimp>
+            <Chinese>邀请</Chinese>
+        </Key>
+        <Key ID="STR_SQUADS_newSquadName">
+            <Original>NEW SQUAD NAME</Original>
+            <English>NEW SQUAD NAME</English>
+            <Czech>NOVÝ NÁZEV DRUŽSTVA</Czech>
+            <French>NOM DE LA NOUVELLE ESCADRON</French>
+            <German>NEUER TRUPPENNAME</German>
+            <Italian>NUOVO NOME DELLA SQUADRA</Italian>
+            <Polish>NOWA NAZWA DRUŻYNY</Polish>
+            <Portuguese>NOME DA NOVA EQUIPE</Portuguese>
+            <Russian>НОВОЕ НАЗВАНИЕ ОТРЯДА</Russian>
+            <Spanish>NUEVO NOMBRE DEL ESCUADRÓN</Spanish>
+            <Turkish>YENİ TAKIM ADI</Turkish>
+            <Korean>새로운 팀 이름</Korean>
+            <Japanese>新しい隊の名前</Japanese>
+            <Chinesesimp>新的小队名称</Chinesesimp>
+            <Chinese>新的小队名称</Chinese>
+        </Key>
+        <Key ID="STR_SQUADS_enterNewSquadName">
+            <Original>Enter the new squad name.</Original>
+            <English>Enter the new squad name.</English>
+            <Czech>Zadejte nový název družstva.</Czech>
+            <French>Entrez le nom de la nouvelle escouade.</French>
+            <German>Geben Sie den neuen Truppennamen ein.</German>
+            <Italian>Inserisci il nuovo nome della squadra.</Italian>
+            <Polish>Wprowadź nową nazwę drużyny.</Polish>
+            <Portuguese>Digite o nome da nova equipe.</Portuguese>
+            <Russian>Введите новое название отряда.</Russian>
+            <Spanish>Ingrese el nuevo nombre del escuadrón.</Spanish>
+            <Turkish>Yeni takım adını girin.</Turkish>
+            <Korean>새 팀 이름을 입력하세요.</Korean>
+            <Japanese>新しい隊の名前を入力してください。</Japanese>
+            <Chinesesimp>输入新的小队名称。</Chinesesimp>
+            <Chinese>输入新的小队名称。</Chinese>
+        </Key>
+        <Key ID="STR_SQUADS_buttonsSave">
+            <Original>SAVE</Original>
+            <English>SAVE</English>
+            <Czech>ULOŽIT</Czech>
+            <French>ENREGISTRER</French>
+            <German>SPEICHERN</German>
+            <Italian>SALVA</Italian>
+            <Polish>ZAPISZ</Polish>
+            <Portuguese>SALVAR</Portuguese>
+            <Russian>СОХРАНИТЬ</Russian>
+            <Spanish>GUARDAR</Spanish>
+            <Turkish>KAYDET</Turkish>
+            <Korean>저장</Korean>
+            <Japanese>保存</Japanese>
+            <Chinesesimp>保存</Chinesesimp>
+            <Chinese>保存</Chinese>
+        </Key>
+        <Key ID="STR_SQUADS_saveNewSquadName">
+            <Original>Save the new squad name.</Original>
+            <English>Save the new squad name.</English>
+            <Czech>Uložit nový název družstva.</Czech>
+            <French>Enregistrez le nom de la nouvelle escouade.</French>
+            <German>Speichern Sie den neuen Truppennamen.</German>
+            <Italian>Salva il nuovo nome della squadra.</Italian>
+            <Polish>Zapisz nową nazwę drużyny.</Polish>
+            <Portuguese>Salve o novo nome da equipe.</Portuguese>
+            <Russian>Сохраните новое название отряда.</Russian>
+            <Spanish>Guarda el nuevo nombre del escuadrón.</Spanish>
+            <Turkish>Yeni takım adını kaydet.</Turkish>
+            <Korean>새 팀 이름을 저장하세요.</Korean>
+            <Japanese>新しい隊の名前を保存します。</Japanese>
+            <Chinesesimp>保存新的小队名称。</Chinesesimp>
+            <Chinese>保存新的小队名称。</Chinese>
+        </Key>
+        <Key ID="STR_SQUADS_refreshSquads">
+            <Original>REFRESH</Original>
+            <English>REFRESH</English>
+            <Czech>OBNOVIT</Czech>
+            <French>ACTUALISER</French>
+            <German>AKTUALISIEREN</German>
+            <Italian>AGGIORNA</Italian>
+            <Polish>ODŚWIEŻ</Polish>
+            <Portuguese>ATUALIZAR</Portuguese>
+            <Russian>ОБНОВИТЬ</Russian>
+            <Spanish>ACTUALIZAR</Spanish>
+            <Turkish>YENİLE</Turkish>
+            <Korean>새로 고침</Korean>
+            <Japanese>更新</Japanese>
+            <Chinesesimp>刷新</Chinesesimp>
+            <Chinese>刷新</Chinese>
+        </Key>
+        <Key ID="STR_SQUADS_squads">
+            <Original>Squads</Original>
+            <English>Squads</English>
+            <Czech>Družstva</Czech>
+            <French>Escouades</French>
+            <German>Truppen</German>
+            <Italian>Squadre</Italian>
+            <Polish>Drużyny</Polish>
+            <Portuguese>Esquadrões</Portuguese>
+            <Russian>Отряды</Russian>
+            <Spanish>Escuadrones</Spanish>
+            <Turkish>Takımlar</Turkish>
+            <Korean>팀</Korean>
+            <Japanese>隊</Japanese>
+            <Chinesesimp>小队</Chinesesimp>
+            <Chinese>小队</Chinese>
+        </Key>
     </Container>
 </Project>

--- a/ui/controls.hpp
+++ b/ui/controls.hpp
@@ -1027,14 +1027,14 @@ class MRTM_settingsMenu
 		class MRTMGroupsButton: RscButtonMRTM
 		{
 			idc = 1605;
-			text = "GROUPS";
+			text = "SQUADS";
 			sizeEx = "0.021 / (getResolution select 5)";
 			x = 0.327969 * safezoneW + safezoneX;
 			y = 0.786 * safezoneH + safezoneY;
 			w = 0.0567187 * safezoneW;
 			h = 0.022 * safezoneH;
 			font = "PuristaMedium";
-			action =  "(findDisplay 8000) closeDisplay 1; true spawn MRTM_fnc_openGroupMenu;";
+			action =  "(findDisplay 8000) closeDisplay 1; [true] call BIS_fnc_squadsMenu;";
 		};
 		class MRTMDebugButton: RscButtonMRTM
 		{

--- a/ui/defines.hpp
+++ b/ui/defines.hpp
@@ -1652,3 +1652,81 @@ class RscControlsGroupMRTM {
 	
 	class Controls {};
 };
+
+class RscTreeWL
+{
+	deletable = 0;
+	fade = 0;
+	access = 0;
+	type = 5;
+	rowHeight = 0;
+	colorText[] = {1, 1, 1, 1};
+	colorDisabled[] = {1, 1, 1, 1};
+	colorScrollbar[] = {1, 0, 0, 0};
+	colorSelect2[] = {0, 0, 0, 1};
+	colorBackground[] = {0, 0, 0, 0.3};
+	soundSelect[] = {"\A3\ui_f\data\sound\RscListbox\soundSelect", 0.09, 1};
+	autoScrollSpeed = -1;
+	autoScrollDelay = 5;
+	autoScrollRewind = 0;
+	arrowEmpty = "#(argb,8,8,3)color(1,1,1,1)";
+	arrowFull = "#(argb,8,8,3)color(1,1,1,1)";
+	colorPicture[] = {1, 1, 1, 1};
+	colorPictureSelected[] = {1, 1, 1, 1};
+	colorPictureDisabled[] = {1, 1, 1, 0.25};
+	colorPictureRight[] = {1, 1, 1, 1};
+	colorPictureRightSelected[] = {1, 1, 1, 1};
+	colorPictureRightDisabled[] = {1, 1, 1, 0.25};
+	colorTextRight[] = {1, 1, 1, 1};
+	colorSelectRight[] = {0, 0, 0, 1};
+	colorSelect2Right[] = {0, 0, 0, 1};
+	tooltipColorText[] = {1, 1, 1, 1};
+	tooltipColorBox[] = {1, 1, 1, 1};
+	tooltipColorShade[] = {0, 0, 0, 0.65};
+	class ListScrollBar
+	{
+		color[] = {1, 1, 1, 1};
+		autoScrollEnabled = 1;
+	};
+	x = 0;
+	y = 0;
+	w = 0.3;
+	h = 0.3;
+	style = 16;
+	font = "RobotoCondensed";
+	sizeEx = "(((((safezoneW / safezoneH) min 1.2) / 1.2) / 25) * 1)";
+	shadow = 0;
+	colorShadow[] = {0, 0, 0, 0};
+	period = 1.2;
+	maxHistoryDelay = 1;
+	expandedTexture = "A3\ui_f\data\gui\rsccommon\rsctree\expandedTexture_ca.paa";
+	hiddenTexture = "A3\ui_f\data\gui\rsccommon\rsctree\hiddenTexture_ca.paa";
+	expandOnDoubleclick = 0;
+	colorSelectText[] = {1, 1, 1, 1};
+	colorBorder[] = {0, 0, 0, 0};
+	colorSearch[] =
+	{
+		"(profilenamespace getvariable ['GUI_BCG_RGB_R',0.13])",
+		"(profilenamespace getvariable ['GUI_BCG_RGB_G',0.54])",
+		"(profilenamespace getvariable ['GUI_BCG_RGB_B',0.21])",
+		"(profilenamespace getvariable ['GUI_BCG_RGB_A',0.8])"
+	};
+	colorSelect[] = {1, 1, 1, 0.3};
+	colorMarked[] = {0.2, 0.3, 0.7, 0.5};
+	colorMarkedText[] = {1, 1, 1, 0.5};
+	colorMarkedSelected[] = {0, 0.5, 0.5, 1};
+	colorSelectBackground[] = {0, 0, 0, 0.5};
+	multiselectEnabled = 0;
+	colorArrow[] = {1, 1, 1, 1};
+	class ScrollBar {
+		color[] = {1, 1, 1, 0.6};
+		colorActive[] = {1, 1, 1, 1};
+		colorDisabled[] = {1, 1, 1, 0.3};
+		thumb = "\A3\ui_f\data\gui\cfg\scrollbar\thumb_ca.paa";
+		arrowFull = "\A3\ui_f\data\gui\cfg\scrollbar\arrowFull_ca.paa";
+		arrowEmpty = "\A3\ui_f\data\gui\cfg\scrollbar\arrowEmpty_ca.paa";
+		border = "\A3\ui_f\data\gui\cfg\scrollbar\border_ca.paa";
+		shadow = 0;
+		scrollSpeed = 0.05;
+	};
+};

--- a/ui/squadMenu.hpp
+++ b/ui/squadMenu.hpp
@@ -1,0 +1,328 @@
+class SquadsMenu
+{
+	idd = 5000;
+
+	class controls
+	{
+		class SquadsBackground: IGUIBackMRTM
+		{
+			idc = 5001;
+			colorBackground[] = {0, 0, 0, 0.9};
+			x = 0.26836 * safezoneW + safezoneX;
+			y = 0.2646 * safezoneH + safezoneY;
+			w = 0.45375 * safezoneW;
+			h = 0.517 * safezoneH;
+		};
+		class SquadsHeaderBackground: IGUIBackMRTM
+		{
+			idc = 5002;
+			colorBackground[] = {"(profilenamespace getvariable ['GUI_BCG_RGB_R',0.3])", "(profilenamespace getvariable ['GUI_BCG_RGB_G',0.7])", "(profilenamespace getvariable ['GUI_BCG_RGB_B',0.8])", "(profilenamespace getvariable ['GUI_BCG_RGB_A',0.7])"};
+			x = 0.267969 * safezoneW + safezoneX;
+			y = 0.235 * safezoneH + safezoneY;
+			w = 0.45375 * safezoneW;
+			h = 0.025 * safezoneH;
+		};
+		class SquadsHeaderTextLeft: RscStructuredTextMRTM
+		{
+			idc = 5003;
+			text = $STR_SQUADS_squadMenuText;
+			colorBackground[] = {0,0,0,0};
+			x = 0.267969 * safezoneW + safezoneX;
+			y = 0.235 * safezoneH + safezoneY;
+			w = 0.154687 * safezoneW;
+			h = 0.033 * safezoneH;
+			class Attributes
+			{
+				font = "PuristaMedium";
+				color = "#ffffff";
+				colorLink = "#D09B43";
+				align = "left";
+				shadow = 1;
+			};
+		};
+		class SquadsInfoText: RscStructuredTextMRTM
+		{
+			idc = 5004;
+			text = $STR_SQUADS_welcomeText;
+			colorBackground[] = {0, 0, 0, 0};
+			x = 0.267969 * safezoneW + safezoneX;
+			y = 0.2706 * safezoneH + safezoneY;
+			w = 0.214687 * safezoneW;
+			h = 0.073 * safezoneH;
+			class Attributes
+			{
+				font = "PuristaMedium";
+				color = "#ffffff";
+				colorLink = "#D09B43";
+				align = "left";
+				shadow = 1;
+				size = 0.88;
+			};
+		};
+        class SquadsSquadList:RscTreeWL
+		{
+			idc = 5005;
+			deletable = 0;
+			canDrag = 0;
+			color[] = {1, 0, 0, 1};
+			colorBackground[] = {0, 0, 0, 0.9};
+			type = CT_TREE;
+			x = 0.275 * safezoneW + safezoneX;
+			y = 0.34 * safezoneH + safezoneY;
+			w = 0.209187 * safezoneW;
+			h = 0.427 * safezoneH;
+			autoScrollSpeed = -1;
+			autoScrollDelay = 5;
+			autoScrollRewind = 0;
+			class ListScrollBar {
+				color[] = {1,1,1,1};
+				thumb = "\A3\ui_f\data\gui\cfg\scrollbar\thumb_ca.paa";
+				arrowFull = "\A3\ui_f\data\gui\cfg\scrollbar\arrowFull_ca.paa";
+				arrowEmpty = "\A3\ui_f\data\gui\cfg\scrollbar\arrowEmpty_ca.paa";
+				border = "\A3\ui_f\data\gui\cfg\scrollbar\border_ca.paa";
+			};
+			style = LB_TEXTURES;
+		};
+		class SquadsPlayersList: RscListboxMRTM
+		{
+			idc = 5006;
+			deletable = 0;
+			canDrag = 0;
+			color[] = {0, 1, 0, 1};
+			colorBackground[] = {0, 0, 0, 0.9};
+			colorSelect[] = {1, 1, 1, 0.3};
+			colorSelectBackground[] = {0, 0, 0, 0};
+			type = CT_LISTBOX;
+			x = 0.487969 * safezoneW + safezoneX;
+			y = 0.310 * safezoneH + safezoneY;
+			w = 0.223981 * safezoneW;
+			h = 0.457 * safezoneH;
+			autoScrollSpeed = -1;
+			autoScrollDelay = 5;
+			autoScrollRewind = 0;
+			class ListScrollBar{
+				color[] = {1,1,1,1};
+				thumb = "\A3\ui_f\data\gui\cfg\scrollbar\thumb_ca.paa";
+				arrowFull = "\A3\ui_f\data\gui\cfg\scrollbar\arrowFull_ca.paa";
+				arrowEmpty = "\A3\ui_f\data\gui\cfg\scrollbar\arrowEmpty_ca.paa";
+				border = "\A3\ui_f\data\gui\cfg\scrollbar\border_ca.paa";
+			};
+			style = LB_TEXTURES;
+		};
+		class SquadsPlayersText: RscStructuredTextMRTM
+		{
+			idc = 5007;
+			text = $STR_SQUADS_squadInviteMenuText;
+			colorBackground[] = {0, 0, 0, 0};
+			x = 0.487969 * safezoneW + safezoneX;
+			y = 0.2706 * safezoneH + safezoneY;
+			w = 0.223981 * safezoneW;
+			h = 0.033 * safezoneH;
+			class Attributes
+			{
+				font = "PuristaMedium";
+				color = "#ffffff";
+				colorLink = "#D09B43";
+				align = "left";
+				shadow = 1;
+				size = 0.88;
+			};
+		};
+		class SquadsRefreshButton: RscCheckboxMRTM
+		{
+			idc = 5008;
+			action = "[false] spawn BIS_fnc_squadsMenu";
+			colorBackgroundHover[] = {1, 1, 1, 0.3};
+			x = 0.69 * safezoneW + safezoneX;
+			y = 0.237 * safezoneH + safezoneY;
+			w = 0.0154688 * safezoneW;
+			h = 0.022 * safezoneH;
+			textureUnChecked = "a3\missions_f_exp\data\img\lobby\ui_campaign_lobby_icon_player_connecting_ca.paa";
+			textureChecked = "a3\missions_f_exp\data\img\lobby\ui_campaign_lobby_icon_player_connecting_ca.paa";
+			textureFocusedChecked = "a3\missions_f_exp\data\img\lobby\ui_campaign_lobby_icon_player_connecting_ca.paa";
+			textureFocusedUnchecked = "a3\missions_f_exp\data\img\lobby\ui_campaign_lobby_icon_player_connecting_ca.paa";
+			textureHoverChecked = "a3\missions_f_exp\data\img\lobby\ui_campaign_lobby_icon_player_connecting_ca.paa";
+			textureHoverUnchecked = "a3\missions_f_exp\data\img\lobby\ui_campaign_lobby_icon_player_connecting_ca.paa";
+			texturePressedChecked = "a3\missions_f_exp\data\img\lobby\ui_campaign_lobby_icon_player_connecting_ca.paa";
+			texturePressedUnchecked = "a3\missions_f_exp\data\img\lobby\ui_campaign_lobby_icon_player_connecting_ca.paa";
+			textureDisabledChecked = "a3\missions_f_exp\data\img\lobby\ui_campaign_lobby_icon_player_connecting_ca.paa";
+			textureDisabledUnchecked = "a3\missions_f_exp\data\img\lobby\ui_campaign_lobby_icon_player_connecting_ca.paa";
+			tooltip = $STR_SQUADS_refreshSquads;
+		};
+		class SquadsCloseButton: RscCheckboxMRTM
+		{
+			idc = 5009;
+			sizeEx = "0.021 / (getResolution select 5)";
+			x = 0.708 * safezoneW + safezoneX;
+			y = 0.237 * safezoneH + safezoneY;
+			w = 0.013 * safezoneW;
+			h = 0.022 * safezoneH;
+			colorBackgroundHover[] = {1, 1, 1, 0.3};
+			font = "PuristaMedium";
+			action = "(findDisplay 5000) closeDisplay 1;";
+			textureUnChecked = "\A3\ui_f\data\map\groupicons\waypoint.paa";
+			textureChecked = "\A3\ui_f\data\map\groupicons\waypoint.paa";
+			textureFocusedChecked = "\A3\ui_f\data\map\groupicons\waypoint.paa";
+			textureFocusedUnchecked = "\A3\ui_f\data\map\groupicons\waypoint.paa";
+			textureHoverChecked = "\A3\ui_f\data\map\groupicons\waypoint.paa";
+			textureHoverUnchecked = "\A3\ui_f\data\map\groupicons\waypoint.paa";
+			texturePressedChecked = "\A3\ui_f\data\map\groupicons\waypoint.paa";
+			texturePressedUnchecked = "\A3\ui_f\data\map\groupicons\waypoint.paa";
+			textureDisabledChecked = "\A3\ui_f\data\map\groupicons\waypoint.paa";
+			textureDisabledUnchecked = "\A3\ui_f\data\map\groupicons\waypoint.paa";
+		};
+		class SquadsLeaveButton: RscButtonMRTM
+		{
+			idc = 5012;
+			text = $STR_SQUADS_buttonsLeave;
+			sizeEx = "0.021 / (getResolution select 5)";
+			colorBackground[] = {0, 0, 0, 0.9};
+			action = "['leave'] spawn BIS_fnc_squadsClient;";
+			x = 0.33 * safezoneW + safezoneX;
+			y = 0.786 * safezoneH + safezoneY;
+			w = 0.05 * safezoneW;
+			h = 0.03 * safezoneH;
+			font = "PuristaMedium";
+		};
+		class SquadsPromoteButton: RscButtonMRTM
+		{
+			idc = 5013;
+			text = $STR_SQUADS_buttonsPromote;
+			sizeEx = "0.021 / (getResolution select 5)";
+			colorBackground[] = {0, 0, 0, 0.9};
+			onLoad = "(_this # 0) ctrlShow false;";
+			action = "['promote'] spawn BIS_fnc_squadsClient;";
+			x = 0.39 * safezoneW + safezoneX;
+			y = 0.786 * safezoneH + safezoneY;
+			w = 0.05 * safezoneW;
+			h = 0.03 * safezoneH;
+			font = "PuristaMedium";
+		};
+		class SquadsKickButton: RscButtonMRTM
+		{
+			idc = 5015;
+			text = $STR_SQUADS_buttonsKick;
+			sizeEx = "0.021 / (getResolution select 5)";
+			colorBackground[] = {0, 0, 0, 0.9};
+			onLoad = "(_this # 0) ctrlShow false;";
+			action = "['kick'] spawn BIS_fnc_squadsClient;";
+			x = 0.45 * safezoneW + safezoneX;
+			y = 0.786 * safezoneH + safezoneY;
+			w = 0.05 * safezoneW;
+			h = 0.03 * safezoneH;
+			font = "PuristaMedium";
+		};
+		class SquadsRenameButton: RscButtonMRTM
+		{
+			idc = 5011;
+			text = $STR_SQUADS_buttonsRename;
+			sizeEx = "0.021 / (getResolution select 5)";
+			colorBackground[] = {0, 0, 0, 0.9};
+			onLoad = "";
+			action = "['rename'] spawn BIS_fnc_squadsClient;";
+			x = 0.51 * safezoneW + safezoneX;
+			y = 0.786 * safezoneH + safezoneY;
+			w = 0.05 * safezoneW;
+			h = 0.03 * safezoneH;
+			font = "PuristaMedium";
+		};
+		class SquadsCreateButton: RscButtonMRTM
+		{
+			idc = 5014;
+			text = $STR_SQUADS_buttonsCreate;
+			sizeEx = "0.021 / (getResolution select 5)";
+			colorBackground[] = {0, 0, 0, 0.9};
+			action = "['create'] spawn BIS_fnc_squadsClient;";
+			x = 0.27 * safezoneW + safezoneX;
+			y = 0.786 * safezoneH + safezoneY;
+			w = 0.05 * safezoneW;
+			h = 0.03 * safezoneH;
+			font = "PuristaMedium";
+		};
+		class SquadsInviteButton: RscButtonMRTM
+		{
+			idc = 5010;
+			text = $STR_SQUADS_buttonsInvite;
+			sizeEx = "0.021 / (getResolution select 5)";
+			colorBackground[] = {0, 0, 0, 0.9};
+			onLoad = "(_this # 0) ctrlEnable false;";
+			tooltip = "Select a player to invite.";
+			action = "['invite'] spawn BIS_fnc_squadsClient;";
+			x = 0.662 * safezoneW + safezoneX;
+			y = 0.272 * safezoneH + safezoneY;
+			w = 0.05 * safezoneW;
+			h = 0.03 * safezoneH;
+			font = "PuristaMedium";
+		};
+	};
+};
+
+
+class SquadsMenu_Rename
+{
+	idd = 5100;
+
+	class controls
+	{
+		class SquadsRenameBackground: IGUIBackMRTM
+		{
+			idc = 5101;
+			colorBackground[] = {0.1, 0.1, 0.1, 0.9};
+			x = 0.41 * safezoneW + safezoneX;
+			y = 0.45 * safezoneH + safezoneY;
+			w = 0.18 * safezoneW;
+			h = 0.12 * safezoneH;
+			class Attributes
+			{
+				font = "PuristaMedium";
+				color = "#ffffff";
+				colorLink = "#D09B43";
+				align = "center";
+				shadow = 1;
+				size = 0.88;
+			};
+		};
+		class SquadsHeaderTextLeft: RscStructuredTextMRTM
+		{
+			idc = 5102;
+			text = $STR_SQUADS_newSquadName;
+			colorBackground[] = {0.2, 0.2, 0.2, 0.9};
+			colorText[] = {1, 1, 1, 1};
+			x = 0.41 * safezoneW + safezoneX;
+			y = 0.45 * safezoneH + safezoneY;
+			w = 0.18 * safezoneW;
+			h = 0.03 * safezoneH;
+			class Attributes
+			{
+				align = "center";
+				shadow = 1;
+				size = 1.2;
+			};
+		};
+		class SquadsRenameEditBox: RscEditMRTM
+		{
+			idc = 5103;
+			x = 0.42 * safezoneW + safezoneX;
+			y = 0.495 * safezoneH + safezoneY;
+			w = 0.16 * safezoneW;
+			h = 0.025 * safezoneH;
+			font = "PuristaMedium";
+			sizeEx = 0.04;
+			tooltip = $STR_SQUADS_enterNewSquadName;
+			maxChars = 20;
+		};
+		class SquadsRenameOkButton: RscButtonMRTM
+		{
+			idc = 5104;
+			text = $STR_SQUADS_buttonsSave;
+			sizeEx = 0.04;
+			action = "['renamed'] spawn BIS_fnc_squadsClient;";
+			x = 0.42 * safezoneW + safezoneX;
+			y = 0.53 * safezoneH + safezoneY;
+			w = 0.16 * safezoneW;
+			h = 0.03 * safezoneH;
+			font = "PuristaMedium";
+			tooltip = $STR_SQUADS_saveNewSquadName;
+		};
+	};
+};


### PR DESCRIPTION
Squad menu:
- triggered via action menu or by talking in group chat
- open, close, refresh
- show squad tree, player list
- create squad, leave
- invite, accept, decline
- squad leader: promote, kick, rename
- auto-promotion when SL leaves
- see points each player has earned (so SL can kick CP leeches)
- see realtime status: no vehicle = rifle icon, vehicle = show vehicle icon, dead = skull icon

Benefits so far:
- Kill rewards are shared in squad. Formula is (reward * 1.5 / # of squadmates).
- Fast travel to squad leader (cost customizable, default to 10 CP)
- Squadmates show up bigger/diff color on screen
- Combine voting (squad leader votes).

# Pictures

## General/Invite

![20240710160715_1](https://github.com/Gamer-Dad/warlordsredux.altis/assets/5867121/e4b805c9-add8-4e07-ba6a-232e7f02fe61)

## Squad Leader actions

![20240710160728_1](https://github.com/Gamer-Dad/warlordsredux.altis/assets/5867121/ca2dfdf5-e70e-4653-853c-443976d54b63)

## Squad rename

![20240710160801_1](https://github.com/Gamer-Dad/warlordsredux.altis/assets/5867121/3f500968-7f73-429c-b1b6-b9968bee220f)

## Receiving invite

![20240710160852_1](https://github.com/Gamer-Dad/warlordsredux.altis/assets/5867121/8b165817-39f1-47a1-92e1-4f9e17bc0d52)

## Different icon types

![20240710161231_1](https://github.com/Gamer-Dad/warlordsredux.altis/assets/5867121/b5974d29-9246-4999-a71f-9a9bf6e6a199)

## Fast travel to squad leader

![20240710161346_1](https://github.com/Gamer-Dad/warlordsredux.altis/assets/5867121/370f9f02-3ebc-4640-9516-56677b6ea142)
