### PR TITLE
Points, support point tweaks

### DIFF
--- a/Functions/client/fn_WL2_killRewardClient.sqf
+++ b/Functions/client/fn_WL2_killRewardClient.sqf
@@ -1,4 +1,4 @@
-params ["_unit", "_reward", ["_assist", false]];
+params ["_unit", "_reward", ["_assist", false], ["_customText", ""]];
 
 disableSerialization;
 
@@ -21,20 +21,30 @@ _ctrl = (findDisplay 46) ctrlCreate ["RscStructuredText", _ctrlNmbr];
 _ctrl ctrlSetPosition [_displayX - (_blockW * 110), _displayY - (_blockH * 30), _blockW * 160, _blockH * 16];
 
 _scale = 0.65 call BIS_fnc_WL2_sub_purchaseMenuGetUIScale;
-if (_unit isKindOf "Man") then {
-	if (_assist) then {
-		_ctrl ctrlSetStructuredText parseText format ["<t size='%2' align='right' color='#228b22'>Kill assist +%1CP</t>", _reward, _scale];
-	} else {
-		_ctrl ctrlSetStructuredText parseText format ["<t size='%2' align='right' color='#228b22'>Enemy killed +%1CP</t>", _reward, _scale];
-	};
+
+private _displayText = "";
+private _displayName = "";
+
+if (_customText != "") then {
+	_displayText = format ["%1 +%2CP", _customText, _reward];
 } else {
-	_displayName = getText (configFile >> "CfgVehicles" >> (typeOf _unit) >> "displayName");
-	if (_assist) then {
-		_ctrl ctrlSetStructuredText parseText format ["<t size='%3' align='right' shadow = '1' color='#228b22'>Assist:%1 +%2CP</t>", _displayName, _reward, _scale];
+	if (_unit isKindOf "Man") then {
+		if (_assist) then {
+			_displayText = "Kill assist %2CP";
+		} else {
+			_displayText = "Enemy killed %2CP";
+		};
 	} else {
-		_ctrl ctrlSetStructuredText parseText format ["<t size='%4' align='right' shadow = '1' color='#228b22'>%1 destroyed %3%2CP</t>", _displayName, _reward, (if (_reward > 0) then {"+"} else {""}), _scale];
+		_displayName = getText (configFile >> "CfgVehicles" >> (typeOf _unit) >> "displayName");
+		if (_assist) then {
+			_displayText = "Assist: %1 %2CP";
+		} else {
+			_displayText = "%1 destroyed %2CP";
+		};
 	};
+	_displayText = format [_displayText, _displayName, if (_reward > 0) then {format ["+%1", _reward]} else {format ["%1", _reward]}];
 };
+_ctrl ctrlSetStructuredText parseText format ["<t size='%1' align='right' color='#228b22'>%2</t>", _scale, _displayText];
 
 WAS_score = true;
 

--- a/Functions/client/fn_WL2_orderFTPodFT.sqf
+++ b/Functions/client/fn_WL2_orderFTPodFT.sqf
@@ -16,6 +16,8 @@ if (side player == west) exitWith {
 		[toUpper localize "STR_A3_WL_popup_travelling_FTVehicle"] spawn BIS_fnc_WL2_smoothText;
 		sleep 1;
 		player setPos _positionFT;
+
+		[player, "ftSupportPoints", _x] remoteExec ["BIS_fnc_WL2_handleClientRequest", 2];
 		sleep 1;
 		titleCut ["", "BLACK IN", 1];
 	} forEach entities "B_Slingload_01_Medevac_F";
@@ -29,6 +31,8 @@ if (side player == east) exitWith {
 		[toUpper localize "STR_A3_WL_popup_travelling_FTVehicle"] spawn BIS_fnc_WL2_smoothText;
 		sleep 1;
 		player moveInCargo _x;
+
+		[player, "ftSupportPoints", _x] remoteExec ["BIS_fnc_WL2_handleClientRequest", 2];
 		sleep 1;
 		titleCut ["", "BLACK IN", 1];
 	} forEach entities "Land_Pod_Heli_Transport_04_medevac_F";

--- a/Functions/client/fn_WL2_orderFTVehicleFT.sqf
+++ b/Functions/client/fn_WL2_orderFTVehicleFT.sqf
@@ -10,6 +10,8 @@ private _vic = ["B_Truck_01_medical_F", "O_Truck_03_medical_F"] select _side;
 	[toUpper localize "STR_A3_WL_popup_travelling_FTVehicle"] spawn BIS_fnc_WL2_smoothText;
 	sleep 1;
 	player moveInCargo _x;
+
+	[player, "ftSupportPoints", _x] remoteExec ["BIS_fnc_WL2_handleClientRequest", 2];
 	sleep 1;
 	titleCut ["", "BLACK IN", 1];
 } forEach ((entities _vic) select {alive _x});

--- a/Functions/common/fn_WL2_newAssetHandle.sqf
+++ b/Functions/common/fn_WL2_newAssetHandle.sqf
@@ -2,6 +2,15 @@
 
 params ["_asset", ["_owner", objNull]];
 
+_asset addEventHandler ["Hit", {
+	params ["_unit", "_source", "_damage", "_instigator"];
+	
+	private _responsiblePlayer = [_source, _instigator] call BIS_fnc_WL2_handleInstigator;
+	if (!(isNull _responsiblePlayer) && _damage > 0 && alive _unit) then {
+		_unit setVariable ["BIS_WL_lastHitter", _responsiblePlayer, true];
+	};
+}];
+
 if (isServer && {isNull _owner}) exitWith {
 	if !(_asset isKindOf "Man") then {
 		call APS_fnc_RegisterVehicle;

--- a/Functions/server/fn_WL2_changeSectorOwnership.sqf
+++ b/Functions/server/fn_WL2_changeSectorOwnership.sqf
@@ -11,6 +11,7 @@ if !(_owner in _previousOwners) then {
 		{
 			private _uid = getPlayerUID _x;
 			_reward call BIS_fnc_WL2_fundsDatabaseWrite;
+			[objNull, _reward, false, "Sector captured"] remoteExec ["BIS_fnc_WL2_killRewardClient", _x];
 		} forEach (allPlayers select {side group _x == _owner});
 	};
 };

--- a/Functions/server/fn_WL2_handleClientRequest.sqf
+++ b/Functions/server/fn_WL2_handleClientRequest.sqf
@@ -96,6 +96,17 @@ if (_action == "orderFTVehicle") exitWith {
 		if ((count ((entities getFTVehicle) select {alive _x})) == 0) then {
 			_asset = createVehicle [getFTVehicle, _sender, [], 0, "NONE"];
 			_asset setVariable ["BIS_WL_ownerAsset", _uid, [2, (owner _sender)]];
+			_asset setVariable ["BIS_WL_rewardedStack", createHashMap];
+			
+			_asset spawn {
+				_asset = _this;
+				while {alive _asset} do {
+					// wipe the reward stack every 2 minutes
+					sleep 120;
+					_asset setVariable ["BIS_WL_rewardedStack", createHashMap];
+				};
+			};
+
 			[_asset, _sender] remoteExec ["BIS_fnc_WL2_newAssetHandle", remoteExecutedOwner];
 		};
 	};
@@ -110,8 +121,48 @@ if (_action == "orderFTPod") exitWith {
 		if ((count (entities getFTPod)) == 0) then {
 			_asset = createVehicle [getFTPod, _sender, [], 0, "NONE"];
 			_asset setVariable ["BIS_WL_ownerAsset", _uid, [2, (owner _sender)]];
+			_asset setVariable ["BIS_WL_rewardedStack", createHashMap];
+
+			_asset spawn {
+				_asset = _this;
+				while {alive _asset} do {
+					sleep 120;
+					_asset setVariable ["BIS_WL_rewardedStack", createHashMap];
+				};
+			};
+
 			[_asset, _sender] remoteExec ["BIS_fnc_WL2_newAssetHandle", remoteExecutedOwner];
 		};
+	};
+};
+
+if (_action == "ftSupportPoints") exitWith {
+	private _ftVehicle = _param1;
+	private _reward = 5;
+
+	private _targets = [
+		missionNamespace getVariable "BIS_WL_currentTarget_west", 
+		missionNamespace getVariable "BIS_WL_currentTarget_east"
+	] select {
+		!(isNull _x)
+	};
+
+	if ((_targets findIf {_sender inArea (_x getVariable "objectAreaComplete")}) != -1) then {	
+		_reward = 10;
+	};
+
+	private _ftVehicleOwner = _ftVehicle getVariable ["BIS_WL_ownerAsset", "123"];
+	private _rewardStack = _ftVehicle getVariable ["BIS_WL_rewardedStack", createHashMap];
+
+	private _eligible = !(_rewardStack getOrDefault [getPlayerUID _sender, false]) && _ftVehicleOwner != _uid;
+	if (_eligible) then {
+		_uid = _ftVehicleOwner;
+		_reward call BIS_fnc_WL2_fundsDatabaseWrite;
+
+		_rewardStack set [getPlayerUID _sender, true];
+		_ftVehicle setVariable ["BIS_WL_rewardedStack", _rewardStack];
+
+		[objNull, _reward, false, "Spawn reward"] remoteExec ["BIS_fnc_WL2_killRewardClient", owner _sender];
 	};
 };
 

--- a/Functions/server/fn_WL2_handleInstigator.sqf
+++ b/Functions/server/fn_WL2_handleInstigator.sqf
@@ -1,0 +1,30 @@
+params ["_damager", "_instigator"];
+
+_ret = objNull;
+
+if (isNull _instigator) then {
+    private _potentialInstigatorByUID = _damager getVariable ["BIS_WL_ownerAsset", "123"] call BIS_fnc_getUnitByUID;
+    _instigator = if !(isNull _potentialInstigatorByUID) then {
+        _potentialInstigatorByUID
+    } else {
+        // Fallback to killer's uav controller
+        (UAVControl vehicle _damager) select 0
+    };
+};
+
+if (isNull _instigator) then {
+    _instigator = vehicle _damager;
+};
+
+/* We should have the instigator beyond this point. */
+
+if !(isNull _instigator) then {
+    private _responsibleLeader = (_instigator getVariable ["BIS_WL_ownerAsset", "123"]) call BIS_fnc_getUnitByUID;
+    
+    // Check if the responsible leader is a player
+    if (isPlayer _responsibleLeader) then {
+        _ret = _responsibleLeader;
+    };
+};
+
+_ret;

--- a/Functions/server/fn_WL2_initServer.sqf
+++ b/Functions/server/fn_WL2_initServer.sqf
@@ -42,6 +42,7 @@ BIS_fnc_WL2_getInfantry = compileFinal preprocessFileLineNumbers "Functions\serv
 BIS_fnc_WL2_getVehicles = compileFinal preprocessFileLineNumbers "Functions\server\sectors\fn_WL2_getVehicles.sqf";
 BIS_fnc_WL2_sectorCaptureHandle = compileFinal preprocessFileLineNumbers "Functions\server\sectors\fn_WL2_sectorCaptureHandle.sqf";
 BIS_fnc_WL2_sectorsInitServer = compileFinal preprocessFileLineNumbers "Functions\server\sectors\fn_WL2_sectorsInitServer.sqf";
+BIS_fnc_WL2_handleInstigator = compileFinal preprocessFileLineNumbers "Functions\server\fn_WL2_handleInstigator.sqf";
 
 BIS_fnc_orderAir = compileFinal preprocessFileLineNumbers "Functions\server\clientRequests\fn_orderAir.sqf";
 BIS_fnc_orderDefence = compileFinal preprocessFileLineNumbers "Functions\server\clientRequests\fn_orderDefence.sqf";

--- a/Functions/server/fn_WL2_serverEHs.sqf
+++ b/Functions/server/fn_WL2_serverEHs.sqf
@@ -26,16 +26,18 @@ addMissionEventHandler ["HandleDisconnect", {
 
 addMissionEventHandler ["EntityKilled", {
 	params ["_unit", "_killer", "_instigator"];
-	if (isNull _instigator) then {_instigator = (if !(isNull ((_killer getVariable ["BIS_WL_ownerAsset", "123"]) call BIS_fnc_getUnitByUID)) then [{((_killer getVariable ["BIS_WL_ownerAsset", "123"]) call BIS_fnc_getUnitByUID)}, {((UAVControl vehicle _killer) # 0)}])};
-	if (isNull _instigator) then {_instigator = (vehicle _killer)};
-	if !(isNull _instigator) then {
-		_responsibleLeader = (_instigator getVariable ["BIS_WL_ownerAsset", "123"]) call BIS_fnc_getUnitByUID;
-		if (isPlayer _responsibleLeader) then {
-			[_unit, _responsibleLeader] spawn BIS_fnc_WL2_killRewardHandle;
-			[_unit, _responsibleLeader] spawn BIS_fnc_WL2_friendlyFireHandleServer;
-			if (isPlayer _unit) then {
-				diag_log format["PvP kill: %1_%2 was killed by %3_%4 from %5m", name _unit, getPlayerUID _unit, name _responsibleLeader, getPlayerUID _responsibleLeader, _unit distance _responsibleLeader];
-			};
+
+	private _responsiblePlayer = [_killer, _instigator] call BIS_fnc_WL2_handleInstigator;
+	if (isNull _responsiblePlayer) then {
+		// only use last hit if no direct killer is found
+		_responsiblePlayer = _unit getVariable ["BIS_WL_lastHitter", objNull];
+	};
+
+	if !(isNull _responsiblePlayer) then {
+		[_unit, _responsiblePlayer] spawn BIS_fnc_WL2_killRewardHandle;
+		[_unit, _responsiblePlayer] spawn BIS_fnc_WL2_friendlyFireHandleServer;
+		if (isPlayer _unit) then {
+			diag_log format["PvP kill: %1_%2 was killed by %3_%4 from %5m", name _unit, getPlayerUID _unit, name _responsiblePlayer, getPlayerUID _responsiblePlayer, _unit distance _responsiblePlayer];
 		};
 	};
 

--- a/Functions/subroutines/fn_WL2_sub_removeAction.sqf
+++ b/Functions/subroutines/fn_WL2_sub_removeAction.sqf
@@ -4,17 +4,23 @@ params ["_asset"];
 private _removeActionID = _asset addAction [
 	"",
 	{
-		_displayName = getText (configFile >> "CfgVehicles" >> (typeOf (_this # 0)) >> "displayName");
+		private _unit = _this # 0;
+		_displayName = getText (configFile >> "CfgVehicles" >> (typeOf _unit) >> "displayName");
 		_result = [format ["Are you sure you would like to delete: %1", _displayName], "Delete asset", true, true] call BIS_fnc_guiMessage;
 
 		if (_result) exitWith {
-			if (unitIsUAV (_this # 0)) then {
-				private _grp = group effectiveCommander (_this # 0);
-				{(_this # 0) deleteVehicleCrew _x} forEach crew (_this # 0);
+			if (unitIsUAV _unit) then {
+				private _grp = group effectiveCommander _unit;
+				{_unit deleteVehicleCrew _x} forEach crew _unit;
 				deleteGroup _grp;
 			};
+
+			private _lastHitter = _unit getVariable ["BIS_WL_lastHitter", objNull];
+			if !(isNull _lastHitter) then {
+				[_unit, _lastHitter] spawn BIS_fnc_WL2_killRewardHandle;
+			};
 			
-			deleteVehicle (_this # 0);
+			deleteVehicle _unit;
 		};
 	},
 	[],


### PR DESCRIPTION
Changes:
1. Owner of spawn truck/pod gets:
  +5 points if someone spawns on it.
  +10 points if someone spawns on it, and it is inside an attack/defend zone.
2. Limits:
  One reward per person who spawns.
  Rate limit resets every 2 minutes.
  Owner of spawn truck doesn't count.
3. Added client indicator for rewards. Added "sector captured" reward indicator.
4. Added last hitter mechanic when no player can be found responsible for a kill.
5. When a vehicle is deliberately removed, the last player that hit it is credited with it to combat remove-shenanigans. (Ignores friendly hits.)