### PR TITLE
Addressed radar operation issues

### DIFF
--- a/Functions/common/fn_WL2_newAssetHandle.sqf
+++ b/Functions/common/fn_WL2_newAssetHandle.sqf
@@ -115,7 +115,7 @@ if (isPlayer _owner) then {
 				_asset spawn {
 					params ["_asset"];
 
-					_asset setVariable ["radarRotation", false];
+					_asset setVariable ["radarRotation", false, true];
 					[_asset, "rotation"] call BIS_fnc_WL2_sub_radarOperate;
 					_lookAtPositions = [0, 45, 90, 135, 180, 225, 270, 315] apply { _asset getRelPos [100, _x] };
 					_radarIter = 0;
@@ -216,8 +216,21 @@ if (isPlayer _owner) then {
 	_crewPosition = (fullCrew [_asset, "", true]) select {!("cargo" in _x)};
 	_radarSensor = (listVehicleSensors _asset) select {{"ActiveRadarSensorComponent" in _x}forEach _x};
 	if ((count _radarSensor > 0) && (count _crewPosition > 1 || (unitIsUAV _asset))) then {
-		_asset setVariable ["radarOperation", false];
+		_asset setVariable ["radarOperation", false, true];
 		_asset setVehicleRadar 2;
 		[_asset, "toggle"] call BIS_fnc_WL2_sub_radarOperate;
+
+		_asset spawn {
+			params ["_asset"];
+			
+			while {alive _asset} do {
+				if (_asset getVariable "radarOperation") then {
+					_asset setVehicleRadar 1;
+				} else {
+					_asset setVehicleRadar 2;
+				};
+				sleep 10;
+			};
+		};
 	};
 };

--- a/Functions/subroutines/fn_WL2_sub_radarOperate.sqf
+++ b/Functions/subroutines/fn_WL2_sub_radarOperate.sqf
@@ -15,7 +15,7 @@ if (_action == "rotation") then {
 				[_asset, "rotation"] call BIS_fnc_WL2_sub_radarOperate;
 			},
 			[],
-			99,
+			0,
 			false,
 			false,
 			"",
@@ -34,15 +34,13 @@ if (_action == "rotation") then {
 			_asset removeAction _actionID;
 			if (_asset getVariable "radarOperation") then {
 				_asset setVariable ["radarOperation", false, true];
-				_asset setVehicleRadar 2;
 			} else {
 				_asset setVariable ["radarOperation", true, true];
-				_asset setVehicleRadar 1;
 			};
 			[_asset, "toggle"] call BIS_fnc_WL2_sub_radarOperate;
 		},
 		[],
-		99,
+		0,
 		false,
 		false,
 		"",


### PR DESCRIPTION
Changed around the following with the automatic radar operation:
1. Lowered the action priority so it isn't at the top.
2. Check to set vehicle radar on/off on an interval instead of trusting it to be set on action change, in case vehicle locality changes.