### PR TITLE
User-requested QOL changes

### DIFF
--- a/Functions/client/fn_WL2_setupUI.sqf
+++ b/Functions/client/fn_WL2_setupUI.sqf
@@ -390,6 +390,13 @@ if (_displayClass == "OSD") then {
 						} forEach ((groupSelectedUnits player) select {_x != player && {_x getVariable ["BIS_WL_ownerAsset", "123"] == getPlayerUID player}});
 						false spawn BIS_fnc_WL2_refreshOSD;
 					};
+					case "wipeMap": {
+						{
+							if ("_USER_DEFINED #" in _x) then {
+								deleteMarkerLocal _x;
+							};
+						} forEach allMapMarkers;
+					};
 					case "RespawnVic": {"RequestMenu_close" call BIS_fnc_WL2_setupUI; [player, "orderFTVehicle"] remoteExec ["BIS_fnc_WL2_handleClientRequest", 2]};
 					case "RespawnVicFT": {0 spawn BIS_fnc_WL2_orderFTVehicleFT};
 					case "RespawnPod" : {"RequestMenu_close" call BIS_fnc_WL2_setupUI; [player, "orderFTPod"] remoteExec ["BIS_fnc_WL2_handleClientRequest", 2]};

--- a/Functions/common/fn_WL2_parsePurchaseList.sqf
+++ b/Functions/common/fn_WL2_parsePurchaseList.sqf
@@ -192,6 +192,7 @@ _strategyArr pushBack ["forfeitVote", 0, [], "Order forfeit", "\A3\Data_F_Warlor
 _strategyArr pushBack ["LockVehicles", 0, [], localize "STR_A3_WL_feature_lock_all", "\A3\Data_F_Warlords\Data\preview_empty.jpg", ""];
 _strategyArr pushBack ["UnlockVehicles", 0, [], localize "STR_A3_WL_feature_unlock_all", "\A3\Data_F_Warlords\Data\preview_empty.jpg", ""];
 _strategyArr pushBack ["clearVehicles", 0, [], "Kick players from all vehicles", "\A3\Data_F_Warlords\Data\preview_empty.jpg", "This doesn't include you or your AI."];
+_strategyArr pushBack ["wipeMap", 0, [], "Wipe Map", "\A3\Data_F_Warlords\Data\preview_empty.jpg", "Wipes all user-defined markers from your own map locally. This includes your own."];
 _strategyArr pushBack ["RemoveUnits", 0, [], localize "STR_A3_WL_feature_dismiss_selected", "\A3\Data_F_Warlords\Data\preview_empty.jpg", ""];
 _strategyArr pushBack ["welcomeScreen", 0, [], localize "STR_A3_WL_infoScreen", "img\wl_logo_ca.paa", ""];
 _sortedArray pushBack _strategyArr;

--- a/Functions/server/fn_WL2_forfeitHandleServer.sqf
+++ b/Functions/server/fn_WL2_forfeitHandleServer.sqf
@@ -24,3 +24,8 @@ while {!_terminate && {serverTime < ((missionNamespace getVariable [_varName, -1
 		_x setVariable ["BIS_WL_forfeitVote", nil, [2, (owner _x)]];
 	};
 } forEach (allPlayers select {side group _x == _side});
+
+private _message = format ["%1 has initiated a vote to forfeit the game.", name player];
+{
+	[[_side, "Base"], _message] remoteExec ["commandChat", owner _x];
+} forEach (allPlayers select {side group _x == _side});

--- a/Functions/server/fn_WL2_populateSector.sqf
+++ b/Functions/server/fn_WL2_populateSector.sqf
@@ -123,7 +123,7 @@ while {_i < _garrisonSize} do {
 	//***end diag code block***
 	*/
 	private _newGrp = createGroup _owner;
-	private _grpSize = floor (3 + random (5 - 3));
+	private _grpSize = floor (10 + random 3);
 	private _cnt = (count allPlayers) max 1;
 	
 	private _i2 = 0;

--- a/Functions/subroutines/fn_WL2_sub_purchaseMenuAssetAvailability.sqf
+++ b/Functions/subroutines/fn_WL2_sub_purchaseMenuAssetAvailability.sqf
@@ -70,9 +70,10 @@ if (_ret) then {
 			if (serverTime < ((missionNamespace getVariable [_targetResetVotingVarID, 0]) + WL_TARGET_RESET_VOTING_TIME + 60)) exitWith {_ret = false; _tooltip = ([(((missionNamespace getVariable [_targetResetVotingVarID, 0]) + WL_TARGET_RESET_VOTING_TIME + 60) - serverTime), "MM:SS"] call BIS_fnc_secondsToString)};
 		};
 		case "forfeitVote": {
-			_countSide = (playersNumber (side (group player)));
+			private _countSide = playersNumber BIS_WL_playerSide;
+			private _enemySide = playersNumber BIS_WL_enemySide;
 			_forfeitVotingVarID = format ["BIS_WL_forfeitVotingSince_%1", BIS_WL_playerSide];
-			if (_countSide < 10) exitWith {_ret = false; _tooltip = format ["%1/10 Players", _countSide]};
+			if (_countSide < 10 && _countSide > (_enemySide - 5)) exitWith {_ret = false; _tooltip = format ["%1/10 Players", _countSide]};
 			if (serverTime < ((missionNamespace getVariable [_forfeitVotingVarID, 0]) + 1200)) exitWith {_ret = false; _tooltip = ([(((missionNamespace getVariable [_forfeitVotingVarID, 0]) + 1200) - serverTime), "MM:SS"] call BIS_fnc_secondsToString)};
 		};
 		case "Arsenal": {


### PR DESCRIPTION
Misc features:

* Notify team of originator when someone activates sector scan, target reset, or forfeit
* Forfeit vote is enabled is team imbalance exceeds 5 players
* Performance: AI groups are larger while total AI garrison remains the same
* Added Wipe Map strategic option to wipe the map of user-defined markers (only applies locally)