### PR TITLE
New variants, remove SEAD helos, hmd improvements and fixes.

### DIFF
--- a/config/east/east_rotarywing.hpp
+++ b/config/east/east_rotarywing.hpp
@@ -28,6 +28,34 @@ class RotaryWing {
         hasHMD = 1;
     }; // "PO-30 Orca (Unarmed)"
 
+    class O_Heli_Transport_04_recon_F {
+        name = "Mi-290 Taru (Recon)";
+        description = "Mi-290 Taru (Recon) is a variant of the Mi-290 Taru with a powerful scanner.";
+        spawn = "O_Heli_Transport_04_box_F";
+        cost = 2000;
+        requirements[] = {"H"};
+        offset[] = {0, 10, 0};
+        killReward = 125;
+        hasHMD = 1;
+        hasScanner = 1;
+        class Pilot: WLTurretDefaults {
+            turret[] = { -1 };
+            removeMagazines[] = {
+                "168Rnd_CMFlare_Chaff_Magazine"
+            };
+            removeWeapons[] = {
+                "CMFlareLauncher"
+            };
+            addMagazines[] = {
+                "240Rnd_CMFlare_Chaff_Magazine",
+                "240Rnd_CMFlare_Chaff_Magazine"
+            };
+            addWeapons[] = {
+                "CMFlareLauncher_Singles"
+            };
+        };
+    };
+
     class O_Heli_Light_02_dynamicLoadout_F {
         cost = 4000;
         requirements[] = {"H"};
@@ -35,6 +63,10 @@ class RotaryWing {
         killReward = 300;
         rearm = 300;
         hasHMD = 1;
+
+        allowPylonMagazines[] = {
+            "PylonMissile_Missile_KH58_INT_x1"
+        };
     }; // "PO-30 Orca"
 
     class O_Heli_Attack_02_dynamicLoadout_F {
@@ -60,7 +92,6 @@ class RotaryWing {
             };
             addMagazines[] = {
                 "240Rnd_CMFlare_Chaff_Magazine",
-                "240Rnd_CMFlare_Chaff_Magazine",
                 "240Rnd_CMFlare_Chaff_Magazine"
             };
             addWeapons[] = {
@@ -69,56 +100,59 @@ class RotaryWing {
         };
     }; // "Mi-48 Kajman"
 
-    class O_Heli_Attack_02_sead_F {
-        name = "Mi-48 Kajman (SEAD)";
-        spawn = "O_Heli_Attack_02_dynamicLoadout_F";
-        cost = 12000;
-        requirements[] = {"H"};
-        offset[] = {0, 11, 0};
-        rearm = 700;
-        killReward = 550;
-        variant = 1;
+    // class O_Heli_Attack_02_sead_F {
+    //     name = "Mi-48 Kajman (SEAD)";
+    //     spawn = "O_Heli_Attack_02_dynamicLoadout_F";
+    //     cost = 12000;
+    //     requirements[] = {"H"};
+    //     offset[] = {0, 11, 0};
+    //     rearm = 700;
+    //     killReward = 550;
+    //     variant = 1;
 
-        disallowMagazines[] = {
-            "PylonMissile_1Rnd_LG_scalpel",
-            "PylonRack_3Rnd_LG_scalpel",
-            "PylonRack_4Rnd_LG_scalpel",
-            "PylonWeapon_300Rnd_20mm_shells",
-            "PylonRack_20Rnd_Rocket_03_HE_F",
-            "PylonRack_20Rnd_Rocket_03_AP_F",
-            "PylonRack_19Rnd_Rocket_Skyfire",
-            "PylonRack_1Rnd_Missile_AA_03_F",
-            "PylonRack_1Rnd_Missile_AGM_01_F",
-            "PylonMissile_1Rnd_Bomb_03_F",
-            "PylonMissile_1Rnd_BombCluster_02_F"
-        };
-        hasHMD = 1;
+    //     disallowMagazines[] = {
+    //         "PylonMissile_1Rnd_LG_scalpel",
+    //         "PylonRack_3Rnd_LG_scalpel",
+    //         "PylonRack_4Rnd_LG_scalpel",
+    //         "PylonWeapon_300Rnd_20mm_shells",
+    //         "PylonRack_20Rnd_Rocket_03_HE_F",
+    //         "PylonRack_20Rnd_Rocket_03_AP_F",
+    //         "PylonRack_19Rnd_Rocket_Skyfire",
+    //         "PylonRack_1Rnd_Missile_AA_03_F",
+    //         "PylonRack_1Rnd_Missile_AGM_01_F",
+    //         "PylonMissile_1Rnd_Bomb_03_F",
+    //         "PylonMissile_1Rnd_BombCluster_02_F"
+    //     };
+    //     hasHMD = 1;
 
-        class Pilot: WLTurretDefaults {
-            turret[] = { -1 };
-            removeMagazines[] = {};
-            removeWeapons[] = {};
-            addMagazines[] = {
-                "240Rnd_CMFlare_Chaff_Magazine",
-                "240Rnd_CMFlare_Chaff_Magazine",
-                "240Rnd_CMFlare_Chaff_Magazine",
-                "magazine_Missile_KH58_x1",
-                "magazine_Missile_KH58_x1",
-                "magazine_Missile_KH58_x1",
-                "magazine_Missile_KH58_x1",
-                "magazine_Missile_KH58_x1",
-                "magazine_Missile_KH58_x1",
-                "magazine_Missile_KH58_x1",
-                "magazine_Missile_KH58_x1",
-                "magazine_Missile_KH58_x1",
-                "magazine_Missile_KH58_x1",
-                "magazine_Missile_KH58_x1",
-                "magazine_Missile_KH58_x1"
-            };
-            addWeapons[] = {
-                "CMFlareLauncher_Singles",
-                "weapon_KH58Launcher"
-            };
-        };
-    };
+    //     class Pilot: WLTurretDefaults {
+    //         turret[] = { -1 };
+    //         removeMagazines[] = {
+    //             "192Rnd_CMFlare_Chaff_Magazine"
+    //         };
+    //         removeWeapons[] = {
+    //             "CMFlareLauncher"
+    //         };
+    //         addMagazines[] = {
+    //             "240Rnd_CMFlare_Chaff_Magazine",
+    //             "240Rnd_CMFlare_Chaff_Magazine",
+    //             "magazine_Missile_KH58_x1",
+    //             "magazine_Missile_KH58_x1",
+    //             "magazine_Missile_KH58_x1",
+    //             "magazine_Missile_KH58_x1",
+    //             "magazine_Missile_KH58_x1",
+    //             "magazine_Missile_KH58_x1",
+    //             "magazine_Missile_KH58_x1",
+    //             "magazine_Missile_KH58_x1",
+    //             "magazine_Missile_KH58_x1",
+    //             "magazine_Missile_KH58_x1",
+    //             "magazine_Missile_KH58_x1",
+    //             "magazine_Missile_KH58_x1"
+    //         };
+    //         addWeapons[] = {
+    //             "CMFlareLauncher_Singles",
+    //             "weapon_KH58Launcher"
+    //         };
+    //     };
+    // };
 };

--- a/config/guer/guer_airdefense.hpp
+++ b/config/guer/guer_airdefense.hpp
@@ -8,6 +8,27 @@ class AirDefense {
         loadable[] = {0, 0, 1};
     };  // "AN/MPQ-105 Radar"
 
+    class I_LT_01_scout_F {
+        cost = 1200;
+        requirements[] = {};
+        rearm = 300;
+
+        killReward = 240;
+        // vehicleSpawn = 1;
+        capValue = 4;
+    };  // "AWC Nyx (Radar)"
+
+    class I_LT_01_AA_F {
+        cost = 1500;
+        requirements[] = {};
+        rearm = 300;
+
+        killReward = 240;
+        capValue = 4;
+        vehicleSpawn = 1;
+        aps = 1;
+    };  // "AWC Nyx (AA)"
+
     class I_E_SAM_System_03_F {
         description = "Long range surface-to-air missile system, capable of engaging aircraft and helicopters. Effective range: >10km.";
         cost = 8000;

--- a/config/guer/guer_heavyvehicles.hpp
+++ b/config/guer/guer_heavyvehicles.hpp
@@ -1,25 +1,4 @@
 class HeavyVehicles {
-    class I_LT_01_scout_F {
-        cost = 1200;
-        requirements[] = {};
-        rearm = 300;
-
-        killReward = 240;
-        vehicleSpawn = 1;
-        capValue = 4;
-    };  // "AWC Nyx (Radar)"
-
-    class I_LT_01_AA_F {
-        cost = 1500;
-        requirements[] = {};
-        rearm = 300;
-
-        killReward = 240;
-        capValue = 4;
-        vehicleSpawn = 1;
-        aps = 1;
-    };  // "AWC Nyx (AA)"
-
     class I_LT_01_AT_F {
         cost = 1500;
         requirements[] = {};

--- a/config/west/west_fixedwing.hpp
+++ b/config/west/west_fixedwing.hpp
@@ -100,6 +100,30 @@ class FixedWing {
         killReward = 300;
     }; // "V-44 X Blackfish (Vic)"
 
+    class B_T_VTOL_01_recon_F {
+        name = "V-44 X Blackfish (Recon)";
+        description = "V-44 X Blackfish (Recon) is a variant of the V-44 X Blackfish with a powerful scanner.";
+        spawn = "B_T_VTOL_01_infantry_F";
+        cost = 2500;
+        requirements[] = {"A"};
+        killReward = 300;
+        hasHMD = 1;
+        hasScanner = 1;
+        class Pilot: WLTurretDefaults {
+            turret[] = { -1 };
+            removeMagazines[] = {};
+            removeWeapons[] = {
+                "CMFlareLauncher_Triples"
+            };
+            addMagazines[] = {
+                "240Rnd_CMFlare_Chaff_Magazine"
+            };
+            addWeapons[] = {
+                "CMFlareLauncher_Singles"
+            };
+        };
+    };
+
     class B_T_VTOL_01_armed_F {
         cost = 8000;
         requirements[] = {"A"};

--- a/config/west/west_rotarywing.hpp
+++ b/config/west/west_rotarywing.hpp
@@ -80,6 +80,45 @@ class RotaryWing {
         killReward = 200;
     }; // "AH-9 Pawnee"
 
+    class B_Heli_Light_01_hmd_F {
+        name = "AH-9 Pawnee Block II";
+        description = "AH-9 Pawnee Block II is a variant of the AH-9 Pawnee with advanced avionics.";
+        spawn = "B_Heli_Light_01_dynamicLoadout_F";
+        cost = 4000;
+        variant = 1;
+        requirements[] = {"H"};
+        textures[] = {
+            "A3\air_f\Heli_Light_01\Data\Skins\Heli_Light_01_ext_digital_co.paa"
+        };
+        killReward = 300;
+        rearm = 300;
+        hasHMD = 1;
+
+        allowPylonMagazines[] = {
+            "PylonRack_Missile_HARM_x1",
+            "PylonRack_3Rnd_LG_scalpel"
+        };
+
+        class Pilot: WLTurretDefaults {
+            turret[] = { -1 };
+            removeMagazines[] = {
+                "5000Rnd_762x51_Belt"
+            };
+            removeWeapons[] = {
+                "M134_minigun"
+            };
+            addMagazines[] = {
+                "240Rnd_CMFlare_Chaff_Magazine",
+                "PylonWeapon_300Rnd_20mm_shells",
+                "PylonWeapon_300Rnd_20mm_shells"
+            };
+            addWeapons[] = {
+                "CMFlareLauncher_Singles",
+                "Twin_Cannon_20mm_gunpod"
+            };
+        };
+    };
+
     class B_Heli_light_03_dynamicLoadout_F {
         cost = 6000;
         name = "WY-55 Hellcat";
@@ -123,7 +162,6 @@ class RotaryWing {
                 "CMFlareLauncher"
             };
             addMagazines[] = {
-                "240Rnd_CMFlare_Chaff_Magazine",
                 "240Rnd_CMFlare_Chaff_Magazine"
             };
             addWeapons[] = {
@@ -132,49 +170,50 @@ class RotaryWing {
         };
     }; // "AH-99 Blackfoot"
 
-    class B_Heli_Attack_01_sead_F {
-        name = "AH-99 Blackfoot (SEAD)";
-        cost = 14000;
-        spawn = "B_Heli_Attack_01_dynamicLoadout_F";
-        requirements[] = {"H"};
-        offset[] = {0, 10, 0};
-        rearm = 700;
-        killReward = 550;
-        variant = 1;
+    // class B_Heli_Attack_01_sead_F {
+    //     name = "AH-99 Blackfoot (SEAD)";
+    //     cost = 14000;
+    //     spawn = "B_Heli_Attack_01_dynamicLoadout_F";
+    //     requirements[] = {"H"};
+    //     offset[] = {0, 10, 0};
+    //     rearm = 700;
+    //     killReward = 550;
+    //     variant = 1;
 
-        disallowMagazines[] = {
-            "PylonMissile_1Rnd_AAA_missiles",
-            "PylonMissile_1Rnd_LG_scalpel",
-            "PylonRack_12Rnd_PG_missiles",
-            "PylonRack_12Rnd_missiles"
-        };
-        hasHMD = 1;
+    //     disallowMagazines[] = {
+    //         "PylonMissile_1Rnd_AAA_missiles",
+    //         "PylonMissile_1Rnd_LG_scalpel",
+    //         "PylonRack_12Rnd_PG_missiles",
+    //         "PylonRack_12Rnd_missiles"
+    //     };
+    //     hasHMD = 1;
 
-        class Pilot: WLTurretDefaults {
-            turret[] = { -1 };
-            removeMagazines[] = {};
-            removeWeapons[] = {};
-            addMagazines[] = {
-                "240Rnd_CMFlare_Chaff_Magazine",
-                "240Rnd_CMFlare_Chaff_Magazine",
-                "240Rnd_CMFlare_Chaff_Magazine",
-                "magazine_Missile_HARM_x1",
-                "magazine_Missile_HARM_x1",
-                "magazine_Missile_HARM_x1",
-                "magazine_Missile_HARM_x1",
-                "magazine_Missile_HARM_x1",
-                "magazine_Missile_HARM_x1",
-                "magazine_Missile_HARM_x1",
-                "magazine_Missile_HARM_x1",
-                "magazine_Missile_HARM_x1",
-                "magazine_Missile_HARM_x1",
-                "magazine_Missile_HARM_x1",
-                "magazine_Missile_HARM_x1"
-            };
-            addWeapons[] = {
-                "CMFlareLauncher_Singles",
-                "weapon_HARMLauncher"
-            };
-        };
-    };
+    //     class Pilot: WLTurretDefaults {
+    //         turret[] = { -1 };
+    //         removeMagazines[] = {};
+    //         removeWeapons[] = {
+    //             "CMFlareLauncher"
+    //         };
+    //         addMagazines[] = {
+    //             "240Rnd_CMFlare_Chaff_Magazine",
+    //             "240Rnd_CMFlare_Chaff_Magazine",
+    //             "magazine_Missile_HARM_x1",
+    //             "magazine_Missile_HARM_x1",
+    //             "magazine_Missile_HARM_x1",
+    //             "magazine_Missile_HARM_x1",
+    //             "magazine_Missile_HARM_x1",
+    //             "magazine_Missile_HARM_x1",
+    //             "magazine_Missile_HARM_x1",
+    //             "magazine_Missile_HARM_x1",
+    //             "magazine_Missile_HARM_x1",
+    //             "magazine_Missile_HARM_x1",
+    //             "magazine_Missile_HARM_x1",
+    //             "magazine_Missile_HARM_x1"
+    //         };
+    //         addWeapons[] = {
+    //             "CMFlareLauncher_Singles",
+    //             "weapon_HARMLauncher"
+    //         };
+    //     };
+    // };
 };

--- a/core/client/draw/fn_iconDrawMap.Sqf
+++ b/core/client/draw/fn_iconDrawMap.Sqf
@@ -75,6 +75,7 @@ if (!isNull WL_SectorActionTarget && isNull BIS_WL_highlightedSector && WL_Secto
 					case west: { [0, 0.3, 0.6, 0.9] };
 					case east: { [0.5, 0, 0, 0.9] };
 					case independent: { [0, 0.6, 0, 0.9] };
+					default { [1, 1, 1, 0] };
 				},
 				call WL2_fnc_getPos,
 				_size,
@@ -130,6 +131,7 @@ _allScannedObjects = _allScannedObjects arrayIntersect _allScannedObjects; // el
 			case west: { [0, 0.3, 0.6, 0.9] };
 			case east: { [0.5, 0, 0, 0.9] };
 			case independent: { [0, 0.6, 0, 0.9] };
+			default { [1, 1, 1, 0] };
 		},
 		call WL2_fnc_getPos,
 		_size,

--- a/core/common/fn_newAssetHandle.sqf
+++ b/core/common/fn_newAssetHandle.sqf
@@ -107,12 +107,13 @@ if (_asset isKindOf "Man") then {
 		// HMD missile alert system
 		_asset addEventHandler ["IncomingMissile", {
 			params ["_target", "_ammo", "_vehicle", "_instigator", "_missile"];
-			private _incomingMissiles = _target getVariable ["WL_incomingMissle", []];
+			private _incomingMissiles = _target getVariable ["WL_incomingMissiles", []];
 			_incomingMissiles pushBack _missile;
 			_incomingMissiles = _incomingMissiles select {
 				alive _x;
 			};
-			_target setVariable ["WL_incomingMissle", _incomingMissiles, true];
+			_target setVariable ["WL_incomingMissiles", _incomingMissiles, true];
+			_target setVariable ["WL_incomingLauncherLastKnown", _vehicle, true];
 		}];
 	};
 

--- a/core/server/sector/fn_sectorsInitServer.sqf
+++ b/core/server/sector/fn_sectorsInitServer.sqf
@@ -20,12 +20,12 @@ _potBases deleteAt (_potBases find _firstBase);
 _potBases = (_potBases select {(_x distanceSqr _firstBase) > _baseDistanceMin});
 private _secondBase = selectRandom _potBases;
 
-// private _presetBase = BIS_WL_allSectors select {
-// 	_x getVariable ["BIS_WL_name", ""] in ["Airbase", "AAC Airfield"];
-// };
+private _presetBase = BIS_WL_allSectors select {
+	_x getVariable ["BIS_WL_name", ""] in ["Kavala", "AAC Airfield"];
+};
 
-// _firstBase = _presetBase # 0;
-// _secondBase = _presetBase # 1;
+_firstBase = _presetBase # 0;
+_secondBase = _presetBase # 1;
 
 missionNamespace setVariable ["BIS_WL_base1", _firstBase, true];
 missionNamespace setVariable ["BIS_WL_base2", _secondBase, true];

--- a/description.ext
+++ b/description.ext
@@ -9,7 +9,7 @@ dev = "Jezuro + WSV";
 author = "Jezuro + WSV";
 allowFunctionsLog = 1;
 zeusCompositionScriptLevel = 2;
-adminIDs[] = {"76561198034106257", "76561198049721952", "76561197960667971"};
+adminIDs[] = {"76561198034106257", "76561198049721952", "76561197960667971", "76561198025492474"};
 
 //Settings
 respawn = 3;

--- a/scripts/WLC/constants.inc
+++ b/scripts/WLC/constants.inc
@@ -2,7 +2,7 @@
 #include "..\..\core\server_macros.inc"
 
 #define WLC_ENABLED true
-#define WLC_DEBUG false
+#define WLC_DEBUG true
 
 #define WLC_DISPLAY 12000
 


### PR DESCRIPTION
New Variants
* Taru Recon: Taru with scanner for $2,000.
* Blackfish Recon: Blackfish with scanner for $2,000.
Balance changes
* Orca can now equip itself with KH58s.
* Blackfoot and Kajman reduced countermeasures to 2 mags.
* Removed attack helo SEAD variants.
Changes
* HMD now shows approaching vs lost missiles correctly, shows launch sites.
* Anti-radiation missile can now lock onto SAMs actively locking it, and onto sites where it detected missile launch.
Fixes
* Fixed error in map draw when non-faction objects are scanned.
* Fixed Nyx (Recon) spawning in green sectors.